### PR TITLE
Problem: source code reloading is enabled by default

### DIFF
--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -4,20 +4,11 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/dashboard/src/:/src/archivematicaCommon/lib/
 ENV PYTHONUNBUFFERED 1
-ENV GUNICORN_CMD_ARGS \
-	--user archivematica \
-	--group archivematica \
-	--bind 0.0.0.0:8000 \
-	--workers 4 \
-	--worker-class gevent \
-	--timeout 172800 \
-	--chdir /src/dashboard/src \
-	--access-logfile - \
-	--error-logfile - \
-	--log-level info \
-	--reload \
-	--reload-engine poll \
-	--name archivematica-dashboard
+ENV GUNICORN_BIND 0.0.0.0:8000
+ENV GUNICORN_CHDIR /src/dashboard/src
+ENV GUNICORN_ACCESSLOG -
+ENV GUNICORN_ERRORLOG -
+ENV FORWARDED_ALLOW_IPS *
 
 RUN set -ex \
 	&& apt-get update \
@@ -33,6 +24,7 @@ ADD archivematicaCommon/ /src/archivematicaCommon/
 ADD dashboard/src/requirements/ /src/dashboard/src/requirements/
 RUN pip install -r /src/dashboard/src/requirements/production.txt -r /src/dashboard/src/requirements/dev.txt
 ADD dashboard/ /src/dashboard/
+ADD dashboard/install/dashboard.gunicorn-config.py /etc/archivematica/dashboard.gunicorn-config.py
 
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \
@@ -55,4 +47,4 @@ RUN env \
 
 EXPOSE 8000
 
-ENTRYPOINT /usr/local/bin/gunicorn wsgi:application
+ENTRYPOINT /usr/local/bin/gunicorn --config=/etc/archivematica/dashboard.gunicorn-config.py wsgi:application

--- a/src/dashboard/install/dashboard.gunicorn-config.py
+++ b/src/dashboard/install/dashboard.gunicorn-config.py
@@ -1,43 +1,60 @@
 # Documentation: http://docs.gunicorn.org/en/stable/configure.html
 # Example: https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
 
+import os
+
 # http://docs.gunicorn.org/en/stable/settings.html#user
-user = "archivematica"
+user = os.environ.get('AM_GUNICORN_USER', 'archivematica')
 
 # http://docs.gunicorn.org/en/stable/settings.html#group
-group = "archivematica"
+group = os.environ.get('AM_GUNICORN_GROUP', 'archivematica')
 
 # http://docs.gunicorn.org/en/stable/settings.html#bind
-bind = "127.0.0.1:8002"
+bind = os.environ.get('AM_GUNICORN_BIND', '127.0.0.1:8002')
 
 # http://docs.gunicorn.org/en/stable/settings.html#workers
-workers = "4"
+workers = os.environ.get('AM_GUNICORN_WORKERS', '4')
+
+# http://docs.gunicorn.org/en/stable/settings.html#worker-class
+worker_class = os.environ.get('AM_GUNICORN_WORKER_CLASS', 'gevent')
 
 # http://docs.gunicorn.org/en/stable/settings.html#timeout
-timeout = "172800"
+timeout = os.environ.get('AM_GUNICORN_TIMEOUT', '172800')
 
 # http://docs.gunicorn.org/en/stable/settings.html#reload
-reload = False
+reload = os.environ.get('AM_GUNICORN_RELOAD', 'false')
+
+# http://docs.gunicorn.org/en/stable/settings.html#reload-engine
+reload_engine = os.environ.get('AM_GUNICORN_RELOAD_ENGINE', 'auto')
 
 # http://docs.gunicorn.org/en/stable/settings.html#chdir
-chdir = "/usr/share/archivematica/dashboard"
+chdir = os.environ.get('AM_GUNICORN_CHDIR', '/usr/share/archivematica/dashboard')
 
 # http://docs.gunicorn.org/en/stable/settings.html#raw-env
-raw_env = [
-    "DJANGO_SETTINGS_MODULE=settings.common",
-]
+envs = (
+    ("DJANGO_SETTINGS_MODULE", "settings.common"),
+)
+raw_env = []
+for e in envs:
+    if e[0] in os.environ:
+        continue
+    raw_env.append('='.join(e))
+
 
 # http://docs.gunicorn.org/en/stable/settings.html#accesslog
-accesslog = "/var/log/archivematica/dashboard/gunicorn.access_log"
+accesslog = os.environ.get('AM_GUNICORN_ACCESSLOG', '/var/log/archivematica/dashboard/gunicorn.access_log')
 
 # http://docs.gunicorn.org/en/stable/settings.html#errorlog
-errorlog = "/var/log/archivematica/dashboard/gunicorn.error_log"
+errorlog = os.environ.get('AM_GUNICORN_ERRORLOG', '/var/log/archivematica/dashboard/gunicorn.error_log')
 
 # http://docs.gunicorn.org/en/stable/settings.html#loglevel
-loglevel = "info"
+loglevel = os.environ.get('AM_GUNICORN_LOGLEVEL', 'info')
 
 # http://docs.gunicorn.org/en/stable/settings.html#proc-name
-proc_name = "archivematica-dashboard"
+proc_name = os.environ.get('AM_GUNICORN_PROC_NAME', 'archivematica-dashboard')
 
 # http://docs.gunicorn.org/en/stable/settings.html#pythonpath
-pythonpath = "/usr/share/archivematica/dashboard,/usr/lib/archivematica/archivematicaCommon"
+pythonpath = os.environ.get('AM_GUNICORN_PYTHONPATH', '/usr/share/archivematica/dashboard,/usr/lib/archivematica/archivematicaCommon')
+
+# http://docs.gunicorn.org/en/stable/settings.html#sendfile
+sendfile = os.environ.get('AM_GUNICORN_SENDFILE', 'false')


### PR DESCRIPTION
Gunicorn's source code auto-reloading is very useful in development environments but it should not be used in production. The Dockerfile in the repo targets production environments.
Developers can still change the defaults via environment strings, e.g. with this PR you can redefine Gunicorn settings with strings like `AM_GUNICORN_RELOAD` or `AM_GUNICORN_RELOAD_ENGINE`.

Related: https://github.com/JiscRDSS/archivematica-storage-service/pull/4