### PR TITLE
Make shibboleth optional

### DIFF
--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -77,16 +77,8 @@ def profile(request):
     else:
         form = ApiKeyForm()
 
-    # load API key for display
-    try:
-        api_key_data = ApiKey.objects.get(user_id=user.pk)
-        api_key = api_key_data.key
-    except ApiKey.DoesNotExist:
-        api_key = _('<no API key generated>')
-
     return render(request, 'accounts/profile.html', {
         'form': form,
-        'api_key': api_key,
         'title': title
     })
 
@@ -144,17 +136,9 @@ def edit(request, id=None):
             suppress_administrator_toggle = False
         form = UserChangeForm(instance=user, suppress_administrator_toggle=suppress_administrator_toggle)
 
-    # load API key for display
-    try:
-        api_key_data = ApiKey.objects.get(user_id=user.pk)
-        api_key = api_key_data.key
-    except:
-        api_key = '<no API key generated>'
-
     return render(request, 'accounts/edit.html', {
         'form': form,
         'user': user,
-        'api_key': api_key,
         'title': title
     })
 

--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -65,6 +65,10 @@ def add(request):
 
 
 def profile(request):
+    # If users are editable in this setup, go to the editable profile view
+    if settings.ALLOW_USER_EDITS:
+        return edit(request)
+
     user = request.user
     title = _('Your profile (%s)') % user
 
@@ -121,10 +125,10 @@ def edit(request, id=None):
                 generate_api_key(user)
 
             # determine where to redirect to
-            if request.user.is_superuser is False:
-                return_view = 'components.accounts.views.edit'
-            else:
+            if request.user.is_superuser:
                 return_view = 'components.accounts.views.list'
+            else:
+                return_view = 'profile'
 
             messages.info(request, _('Saved.'))
             return redirect(return_view)

--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
+from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.models import User
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.template import RequestContext
 from django.utils.translation import ugettext as _
 
@@ -94,11 +95,8 @@ def edit(request, id=None):
         user = request.user
         title = 'Edit your profile (%s)' % user
     else:
-        try:
-            user = User.objects.get(pk=id)
-            title = 'Edit user %s' % user
-        except:
-            raise Http404
+        user = get_object_or_404(User, pk=id)
+        title = 'Edit user %s' % user
 
     # Form
     if request.method == 'POST':

--- a/src/dashboard/src/installer/middleware.py
+++ b/src/dashboard/src/installer/middleware.py
@@ -33,5 +33,11 @@ class ConfigurationCheckMiddleware:
         # The presence of the UUID is an indicator of whether we've already set up.
         dashboard_uuid = helpers.get_setting('dashboard_uuid')
         if not dashboard_uuid:
+            # Start off the installer
             if reverse('installer.views.welcome') != request.path_info:
                 return redirect('installer.views.welcome')
+        elif not request.user.is_authenticated():
+            # Installation already happened - make sure the user is logged in.
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return redirect(settings.LOGIN_URL)

--- a/src/dashboard/src/installer/views.py
+++ b/src/dashboard/src/installer/views.py
@@ -16,12 +16,15 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.contrib import messages
+from django.contrib.auth import authenticate, login
+from django.contrib.auth.models import User
 from django.shortcuts import redirect, render
 from django.utils.translation import ugettext as _
+from tastypie.models import ApiKey
 
 import components.helpers as helpers
 from components.administration.forms import StorageSettingsForm
-from installer.forms import OrganizationForm
+from installer.forms import OrganizationForm, SuperUserCreationForm
 from installer.steps import download_fpr_rules, setup_pipeline, setup_pipeline_in_ss, submit_fpr_agent
 
 
@@ -31,16 +34,33 @@ def welcome(request):
     if dashboard_uuid:
         return redirect('main.views.home')
 
+    # Do we need to set up a user?
+    set_up_user = not User.objects.exists()
+
     if request.method == 'POST':
         # save organization PREMIS agent if supplied
         setup_pipeline(
             org_name=request.POST.get('org_name', ''),
             org_identifie=request.POST.get('org_identifier', '')
         )
-        request.session['first_login'] = True
-        return redirect('installer.views.fprconnect')
+
+        if set_up_user:
+            form = SuperUserCreationForm(request.POST)
+            if form.is_valid():
+                user = form.save()
+                api_key = ApiKey.objects.create(user=user)
+                api_key.key = api_key.generate_key()
+                api_key.save()
+                user = authenticate(username=user.username, password=form.cleaned_data['password1'])
+                if user is not None:
+                    login(request, user)
+                    request.session['first_login'] = True
+                    return redirect('installer.views.fprconnect')
+        else:
+            request.session['first_login'] = True
+            return redirect('installer.views.fprconnect')
     else:
-        form = OrganizationForm()
+        form = SuperUserCreationForm() if set_up_user else OrganizationForm()
 
     return render(request, 'installer/welcome.html', {
         'form': form,

--- a/src/dashboard/src/main/templatetags/user.py
+++ b/src/dashboard/src/main/templatetags/user.py
@@ -1,0 +1,13 @@
+from django import template
+from django.utils.translation import ugettext as _
+from tastypie.models import ApiKey
+
+register = template.Library()
+
+
+@register.filter
+def api_key(user):
+    try:
+        return user.api_key.key
+    except ApiKey.DoesNotExist:
+        return _('<no API key generated>')

--- a/src/dashboard/src/main/templatetags/user.py
+++ b/src/dashboard/src/main/templatetags/user.py
@@ -1,4 +1,5 @@
 from django import template
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from tastypie.models import ApiKey
 
@@ -11,3 +12,11 @@ def api_key(user):
         return user.api_key.key
     except ApiKey.DoesNotExist:
         return _('<no API key generated>')
+
+
+@register.simple_tag(takes_context=True)
+def logout_link(context):
+    if context.get('logout_link'):
+        return context['logout_link']
+    else:
+        return reverse('django.contrib.auth.views.logout_then_login')

--- a/src/dashboard/src/main/urls.py
+++ b/src/dashboard/src/main/urls.py
@@ -44,5 +44,9 @@ urlpatterns = [
     url(r'formdata/(?P<type>\w+)/(?P<parent_id>\d+)/(?P<delete_id>\d+)/$', views.formdata_delete),
     url(r'formdata/(?P<type>\w+)/(?P<parent_id>\d+)/$', views.formdata),
 
-    url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
 ]
+
+if 'shibboleth' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
+    ]

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r test.txt
 
 ipython
+ipdb

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -410,14 +410,12 @@ if SHIBBOLETH_AUTHENTICATION:
         'HTTP_ENTITLEMENT': (True, 'entitlement'),
     }
 
-    # If the user has this entitlement, they will be a superuser/admin
-    SHIBBOLETH_ADMIN_ENTITLEMENT = 'preservation-admin'
-
-
     TEMPLATES[0]['OPTIONS']['context_processors'] += [
-        'shibboleth.context_processors.login_link',
         'shibboleth.context_processors.logout_link',
     ]
+
+    # If the user has this entitlement, they will be a superuser/admin
+    SHIBBOLETH_ADMIN_ENTITLEMENT = 'preservation-admin'
 
     AUTHENTICATION_BACKENDS += [
         'components.accounts.backends.CustomShibbolethRemoteUserBackend',

--- a/src/dashboard/src/templates/accounts/edit.html
+++ b/src/dashboard/src/templates/accounts/edit.html
@@ -1,5 +1,6 @@
 {% extends "layout_fluid.html" %}
 {% load breadcrumb %}
+{% load user %}
 {% load i18n %}
 
 {% block title %}{% blocktrans with user=user %}Users - Edit {{ user }}{% endblocktrans %}{% endblock %}
@@ -29,7 +30,7 @@
         {% include "_form.html" %}
 
         <div>
-          <div class='input'><code>{{ api_key }}</code></div>
+          <div class='input'><code>{{ user|api_key }}</code></div>
         </div>
 
         <div class="actions">

--- a/src/dashboard/src/templates/accounts/profile.html
+++ b/src/dashboard/src/templates/accounts/profile.html
@@ -1,5 +1,6 @@
 {% extends "layout_fluid.html" %}
 {% load breadcrumb %}
+{% load user %}
 {% load i18n %}
 
 {% block title %}Users - Edit {{ user }}{% endblock %}
@@ -38,7 +39,7 @@
         {% include "_form.html" %}
 
         <div>
-          <div class='input'><code>{{ api_key }}</code></div>
+          <div class='input'><code>{{ user|api_key }}</code></div>
         </div>
 
         <div class="actions">

--- a/src/dashboard/src/templates/layout.html
+++ b/src/dashboard/src/templates/layout.html
@@ -1,6 +1,7 @@
 {% load active %}
 {% load i18n %}
 {% load static %}
+{% load user %}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -70,7 +71,7 @@
                   <ul class="dropdown-menu" aria-labelledby="dropdownUser">
                     <li><a href="{% url 'components.accounts.views.profile' %}">{% trans "Your profile" %}</a></li>
                     <li class="divider"></li>
-                    <li><a href="{{ logout_link }}">{% trans "Log out" %}</a></li>
+                    <li><a href="{% logout_link %}">{% trans "Log out" %}</a></li>
                   </ul>
                 </li>
               {% endif %}

--- a/src/dashboard/tests/test_access.py
+++ b/src/dashboard/tests/test_access.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from main import models
+from components import helpers
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -20,6 +21,7 @@ class TestAccessAPI(TestCase):
     def setUp(self):
         self.client = Client()
         self.client.login(username='test', password='test')
+        helpers.set_setting('dashboard_uuid', 'test-uuid')
 
     def test_creating_arrange_directory(self):
         record_id = '/repositories/2/archival_objects/2'

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
 
+from components import helpers
 from main import models
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -21,6 +22,7 @@ class TestSIPArrange(TestCase):
     def setUp(self):
         self.client = Client()
         self.client.login(username='test', password='test')
+        helpers.set_setting('dashboard_uuid', 'test-uuid')
 
     def test_fixtures(self):
         objs = models.SIPArrange.objects.all()

--- a/src/dashboard/tests/test_shibboleth_login.py
+++ b/src/dashboard/tests/test_shibboleth_login.py
@@ -1,9 +1,13 @@
+import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from components import helpers
 
 
+@pytest.mark.skipif(not settings.SHIBBOLETH_AUTHENTICATION,
+                    reason='tests will only pass if Shibboleth is enabled')
 class TestShibbolethLogin(TestCase):
     def setUp(self):
         helpers.set_setting('dashboard_uuid', 'test-uuid')

--- a/src/dashboard/tests/test_shibboleth_login.py
+++ b/src/dashboard/tests/test_shibboleth_login.py
@@ -1,15 +1,19 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from components import helpers
+
 
 class TestShibbolethLogin(TestCase):
+    def setUp(self):
+        helpers.set_setting('dashboard_uuid', 'test-uuid')
+
     def test_with_no_shibboleth_headers(self):
         response = self.client.get('/transfer/')
 
-        # If no shibboleth headers, no user is created - so installer middleware
-        # kicks in and redirects to welcome page
+        # No shibboleth headers, no login
         assert response.status_code == 302
-        assert '/welcome/' in response.url
+        assert '/login/' in response.url
 
     def test_auto_creates_user(self):
         shib_headers = {

--- a/src/dashboard/tests/test_templatetags.py
+++ b/src/dashboard/tests/test_templatetags.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from tastypie.models import ApiKey
 
-from main.templatetags.user import api_key
+from main.templatetags.user import api_key, logout_link
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -23,3 +23,13 @@ class TestAPIKeyTemplateTag(TestCase):
         ApiKey.objects.create(user=self.user, key='my-api-key')
 
         assert api_key(self.user) == 'my-api-key'
+
+
+class TestLogoutLinkTemplateTag(TestCase):
+    def test_uses_logout_link_from_context_when_available(self):
+        context = {'logout_link': '/shibboleth/logout'}
+        assert logout_link(context) == '/shibboleth/logout'
+
+    def test_uses_django_logout_when_logout_link_not_set(self):
+        context = {}
+        assert logout_link(context) == '/administration/accounts/logout/'

--- a/src/dashboard/tests/test_templatetags.py
+++ b/src/dashboard/tests/test_templatetags.py
@@ -1,0 +1,25 @@
+import os
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from tastypie.models import ApiKey
+
+from main.templatetags.user import api_key
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestAPIKeyTemplateTag(TestCase):
+    fixture_files = ['test_user.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def setUp(self):
+        self.user = User.objects.get(username='test')
+
+    def test_shows_api_key_when_set(self):
+        assert api_key(self.user) == '<no API key generated>'
+
+    def test_shows_message_when_no_api_key(self):
+        ApiKey.objects.create(user=self.user, key='my-api-key')
+
+        assert api_key(self.user) == 'my-api-key'


### PR DESCRIPTION
This allows Shibboleth auth to be switched on and off from the environment using `ARCHIVEMATICA_DASHBOARD_SHIBBOLETH_AUTHENTICATION`. Enabling this setting will switch on Shibboleth middleware and other settings.

It also toggles an `ALLOW_USER_EDITS` setting so that users can be editable and change their passwords under normal (model) authentication, but see a read only version of that with Shibboleth. This is a concept that could be extended to other forms of remote authentication. Some of the work here is restoring code that was removed in #5 and making it conditional on ALLOW_USER_EDITS.

I've also got the tests passing again here - changes to the welcome screen logic had been breaking a few of them, so some extra setup was required. Note that the travis job doesn't pass due to flake8 issues in another part of the code (I see that's already being addressed in #17 so will leave it alone)

See also https://github.com/JiscRDSS/rdss-archivematica/pull/25 and https://github.com/JiscRDSS/archivematica-storage-service/pull/6