### PR TITLE
MCPClient: install uuid in Dockerfile

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -50,6 +50,7 @@ RUN set -ex \
 		tree \
 		ufraw \
 		unrar-free \
+		uuid \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Build dependencies


### PR DESCRIPTION
`verifyMD5_v0.0` complains because the `uuid` command is not available. Related to: https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/pull/25.

![image](https://user-images.githubusercontent.com/606459/27347213-a2909bd0-55a4-11e7-92d2-7ac02e7512e9.png)