### PR TITLE
Set higher timeout for copy files API call

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -215,7 +215,7 @@ def copy_files(source_location, destination_location, files):
 
     url = _storage_service_url() + 'location/' + destination_location['uuid'] + '/'
     try:
-        response = _storage_api_session().post(url, json=move_files)
+        response = _storage_api_session(timeout=300).post(url, json=move_files)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to move files with %s because %s", move_files, e.content)

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -7,6 +7,8 @@ import requests
 from requests.auth import AuthBase
 import urllib
 
+from django.conf import settings
+
 # archivematicaCommon
 from archivematicaFunctions import get_setting
 
@@ -215,7 +217,8 @@ def copy_files(source_location, destination_location, files):
 
     url = _storage_service_url() + 'location/' + destination_location['uuid'] + '/'
     try:
-        response = _storage_api_session(timeout=300).post(url, json=move_files)
+        timeout = settings.COPY_FILES_TIMEOUT
+        response = _storage_api_session(timeout).post(url, json=move_files)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to move files with %s because %s", move_files, e.content)

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -33,6 +33,7 @@ CONFIG_MAPPING = {
     'elasticsearch_timeout': {'section': 'Dashboard', 'option': 'elasticsearch_timeout', 'type': 'float'},
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
+    'copy_files_timeout': {'section': 'Dashboard', 'option': 'copy_files_timeout', 'type': 'int'},
 
     # [client]
     'db_engine': {'section': 'client', 'option': 'engine', 'type': 'string'},
@@ -51,6 +52,7 @@ elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
+copy_files_timeout = 300
 # django_allowed_hosts = ... Mandatory!
 # django_secret_key = ... Mandatory!
 
@@ -394,6 +396,8 @@ ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 
 ALLOW_USER_EDITS = True
+
+COPY_FILES_TIMEOUT = config.get('copy_files_timeout')
 
 SHIBBOLETH_AUTHENTICATION = config.get('shibboleth_authentication')
 if SHIBBOLETH_AUTHENTICATION:


### PR DESCRIPTION
This should give storage service time to process larger files before the API call times out.

Ref RDSSARK-221 and https://github.com/JiscRDSS/rdss-archivematica/issues/56

see also https://github.com/artefactual/archivematica/pull/715 and https://github.com/artefactual/archivematica/issues/712

It may be worth making the value configurable as there will still be an upper limit on the size of file that can be processed (ref. https://groups.google.com/forum/#!topic/archivematica/WlFIQ13BkOI) but I'm not sure what the best approach is there - we don't have access to django settings there so an archivematica setting would make more sense... maybe included in the storage settings form? I don't want to hold up the fix by deciding what to do there so perhaps that can be dealt with later.