### PR TITLE
MCPClient: fido workaround

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -80,6 +80,9 @@ ADD MCPClient/requirements/ /src/MCPClient/requirements/
 RUN pip install -r /src/MCPClient/requirements/production.txt -r /src/MCPClient/requirements/dev.txt
 ADD MCPClient/ /src/MCPClient/
 
+# Workaround for https://github.com/artefactual/archivematica-fpr-admin/issues/49
+ADD archivematicaCommon/lib/externals/fido/archivematica_format_extensions.xml /usr/lib/archivematica/archivematicaCommon/externals/fido/archivematica_format_extensions.xml
+
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \
 	&& useradd --uid 333 --gid 333 --system archivematica


### PR DESCRIPTION
fpr-admin expects archivematica_format_extensions.xml to be in a particular
location and it's hard-coded in a script kept in the user database. This is a
workaround until the following is addressed properly:
artefactual/archivematica-fpr-admin#49

This closes:
- JiscRDSS/rdss-archivematica#39
- https://jiscdev.atlassian.net/browse/RDSSARK-228