### PR TITLE
Email: Use env vars for all settings, and add Amazon SES support

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -18,6 +18,7 @@
 import StringIO
 
 from appconfig import Config
+import email_settings
 
 
 CONFIG_MAPPING = {
@@ -49,6 +50,8 @@ CONFIG_MAPPING = {
     'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'int'},
 }
 
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
+
 CONFIG_DEFAULTS = """[MCPClient]
 MCPArchivematicaServer = localhost:4730
 sharedDirectoryMounted = /var/archivematica/sharedDirectory/
@@ -74,6 +77,23 @@ database = MCP
 max_overflow = 40
 port = 3306
 engine = django_mysqlpool.backends.mysqlpool
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+amazon_ses_region = us-east-1
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
@@ -164,3 +184,6 @@ TEMP_DIRECTORY = config.get('temp_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 CLAMAV_SERVER = config.get('clamav_server')
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -1,6 +1,7 @@
 bagit==1.5.2
 clamd==1.0.2
 Django>=1.8,<1.9
+django-amazon-ses==0.3.0
 django-annoying==0.7.7
 django-autoslug==1.7.1
 django-mysqlpool==0.1-9

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -18,6 +18,7 @@
 import StringIO
 
 from appconfig import Config
+import email_settings
 
 
 CONFIG_MAPPING = {
@@ -48,6 +49,7 @@ CONFIG_MAPPING = {
     'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'int'},
 }
 
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
 
 CONFIG_DEFAULTS = """[MCPServer]
 MCPArchivematicaServer = localhost:4730
@@ -74,6 +76,23 @@ database = MCP
 max_overflow = 40
 port = 3306
 engine = django_mysqlpool.backends.mysqlpool
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+amazon_ses_region = us-east-1
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 
@@ -150,3 +169,6 @@ LIMIT_TASK_THREADS = config.get('limit_task_threads')
 LIMIT_TASK_THREADS_SLEEP = config.get('limit_task_threads_sleep')
 LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
 RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -1,4 +1,5 @@
 Django>=1.8,<1.9
+django-amazon-ses==0.3.0
 django-mysqlpool==0.1-9
 django-extensions==1.1.1
 mysqlclient==1.3.7

--- a/src/archivematicaCommon/lib/email_settings.py
+++ b/src/archivematicaCommon/lib/email_settings.py
@@ -1,0 +1,78 @@
+"""
+
+Email settings and globals.
+
+The main setting is `EMAIL_BACKEND`, which defines which backend to use. Valid
+backends are:
+
+* Amazon SES: `django_amazon_ses.backends.boto.EmailBackend`
+* Console: `django.core.mail.backends.console.EmailBackend`
+* Dummy: `django.core.mail.backends.dummy.EmailBackend`
+* File: `django.core.mail.backends.filebased.EmailBackend`
+* In-Memory: `django.core.mail.backends.locmem.EmailBackend`
+* SMTP: `django.core.mail.backends.smtp.EmailBackend`
+
+By default, the Console backend will be used.
+
+"""
+
+from __future__ import absolute_import
+
+CONFIG_MAPPING = {
+    # [email]
+    'email_backend': {'section': 'email', 'option': 'backend', 'type': 'string'},
+    'email_host': {'section': 'email', 'option': 'host', 'type': 'string'},
+    'email_host_user': {'section': 'email', 'option': 'host_user', 'type': 'string'},
+    'email_host_password': {'section': 'email', 'option': 'host_password', 'type': 'string'},
+    'email_port': {'section': 'email', 'option': 'port', 'type': 'int'},
+    'email_ssl_certfile': {'section': 'email', 'option': 'ssl_certfile', 'type': 'string'},
+    'email_ssl_keyfile': {'section': 'email', 'option': 'ssl_keyfile', 'type': 'string'},
+    'email_use_ssl': {'section': 'email', 'option': 'use_ssl', 'type': 'boolean'},
+    'email_use_tls': {'section': 'email', 'option': 'use_tls', 'type': 'boolean'},
+    'email_file_path': {'section': 'email', 'option': 'file_path', 'type': 'string'},
+    'email_amazon_ses_region': {'section': 'email', 'option': 'amazon_ses_region', 'type': 'string'},
+    'default_from_email': {'section': 'email', 'option': 'default_from_email', 'type': 'string'},
+    'email_subject_prefix': {'section': 'email', 'option': 'subject_prefix', 'type': 'string'},
+    'email_timeout': {'section': 'email', 'option': 'timeout', 'type': 'int'},
+    'server_email': {'section': 'email', 'option': 'server_email', 'type': 'int'},
+}
+
+
+def get_settings(config):
+    """
+    Extract a dict of Django email settings from the passed config object
+
+    This should be invoked from a Django settings module and the result merged
+    into the globals() dict.
+    """
+    settings = dict(
+        # Which backend to use?
+        EMAIL_BACKEND=config.get('email_backend'),
+
+        # Amazon SES Backend
+        # See https://github.com/azavea/django-amazon-ses
+        DJANGO_AMAZON_SES_REGION=config.get('email_amazon_ses_region'),
+
+        # File Backend
+        # See https://docs.djangoproject.com/en/dev/topics/email/#file-backend
+        EMAIL_FILE_PATH=config.get('email_file_path'),
+
+        # SMTP Backend
+        # See https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend
+        EMAIL_HOST=config.get('email_host'),
+        EMAIL_HOST_PASSWORD=config.get('email_host_password'),
+        EMAIL_HOST_USER=config.get('email_host_user'),
+        EMAIL_PORT=config.get('email_port'),
+        EMAIL_SSL_CERTFILE=config.get('email_ssl_certfile'),
+        EMAIL_SSL_KEYFILE=config.get('email_ssl_keyfile'),
+        EMAIL_USE_SSL=config.get('email_use_ssl'),
+        EMAIL_USE_TLS=config.get('email_use_tls'),
+
+        # General settings, not backend-specific
+        DEFAULT_FROM_EMAIL=config.get('default_from_email'),
+        EMAIL_SUBJECT_PREFIX=config.get('email_subject_prefix'),
+        EMAIL_TIMEOUT=config.get('email_timeout', None),
+    )
+
+    settings['SERVER_EMAIL'] = config.get('server_email', settings['EMAIL_HOST_USER'])
+    return settings

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -8,6 +8,7 @@ django-model-utils==1.3.1
 logutils==0.3.3
 django-tastypie==0.13.2
 django-extensions==1.1.1
+django-amazon-ses==0.3.0
 django-autoslug==1.7.1
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -21,6 +21,7 @@ import os
 from django.utils.translation import ugettext_lazy as _
 
 from appconfig import Config
+import email_settings
 
 
 CONFIG_MAPPING = {
@@ -45,6 +46,8 @@ CONFIG_MAPPING = {
     'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'int'},
 }
 
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
+
 CONFIG_DEFAULTS = """[Dashboard]
 shared_directory = /var/archivematica/sharedDirectory/
 watch_directory = /var/archivematica/sharedDirectory/watchedDirectories/
@@ -64,6 +67,23 @@ database = MCP
 max_overflow = 40
 port = 3306
 engine = django_mysqlpool.backends.mysqlpool
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+amazon_ses_region = us-east-1
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
@@ -268,12 +288,6 @@ INSTALLED_APPS = [
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
-# For configuration option details see:
-# https://docs.djangoproject.com/en/1.8/ref/settings/#email-backend
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = '127.0.0.1'
-EMAIL_TIMEOUT = 15
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -436,3 +450,6 @@ if SHIBBOLETH_AUTHENTICATION:
     INSTALLED_APPS += ['shibboleth']
 
     ALLOW_USER_EDITS = False
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))


### PR DESCRIPTION
This addresses issue #32.

As with https://github.com/JiscRDSS/archivematica-storage-service/pull/18 for the Storage Service, we need to make the send email settings for Archivematica more configurable, and want to add support for using the Amazon SES backend to send emails.

The changes here use the changes that were added to the Storage Service as a template; however here we have three different modules, the `dashboard`, `MCPClient` and `MCPServer` that each need configuring seperately. Consequently I've updated the settings for each, and added the `django-amazon-ses` module as a `base` dependency for each (though see the discussion in https://github.com/JiscRDSS/archivematica-storage-service/pull/18 about how this will need revising when merged upstream).

The email settings themselves are identical for each component, so I've put them into a seperate `email.py` settings file, which is then imported from `common.py` settings. This avoids the email specific settings from cluttering the rest of the Archivematica-specific settings.

I think these changes are correct, but they're very difficult to test. The original bug report, https://jiscdev.atlassian.net/browse/RDSSARK-230, reported that the `normalizeReport.py` client script in the MCPClient wasn't working, but there are probably other instances where emails are attempting to be sent. As an Archivematica novice, I'm looking for input and feedback from @jhsimpson, @sevein and @helenst for help with validating that these changes actually do the job, and that what I've included in this PR is a complete solution.

So, please review the changes I've made, see if you think they're correct, and advise on how we can best test them. Thank you.