### PR TITLE
Allow transfer names to begin with a dash

### DIFF
--- a/src/dashboard/src/main/migrations/0034_compress_aip_quote_arg.py
+++ b/src/dashboard/src/main/migrations/0034_compress_aip_quote_arg.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration_put_quotes_in_compress_aip_args(apps, schema_editor):
+    StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
+
+    tasks = (
+        # upload-archivesspace.py
+        ('10a0f352-aeb7-4c13-8e9e-e81bda9bca29', u'--host="%host%" --port="%port%" --user="%user%" --passwd="%passwd%" --dip_location="%SIPDirectory%" --dip_name="%SIPName%" --dip_uuid="%SIPUUID%" --restrictions="%restrictions%" --object_type="%object_type%" --xlink_actuate="%xlink_actuate%" --xlink_show="%xlink_show%" --use_statement "%use_statement%" --uri_prefix "%uri_prefix%" --access_conditions "%access_conditions%" --use_conditions="%use_conditions%" --inherit_notes="%inherit_notes%"'),
+        # storeAIP.py
+        ('1e4ccd56-a076-4aa2-9642-1ed8944b306a', u'-- "%DIPsStore%" "%watchDirectoryPath%uploadedDIPs/%SIPName%-%SIPUUID%" "%SIPUUID%" "%SIPName%" "DIP"'),
+        ('1f6f0cd1-acaf-40fb-bb2a-047383b8c977', u'-- "%DIPsStore%" "%watchDirectoryPath%uploadDIP/%SIPName%-%SIPUUID%" "%SIPUUID%" "%SIPName%" "DIP"'),
+        ('7df9e91b-282f-457f-b91a-ad6135f4337d', u'-- "%AIPsStore%" "%SIPDirectory%%AIPFilename%" "%SIPUUID%" "%SIPName%" "%SIPType%"'),
+        # createPointerFile.py
+        ('45f11547-0df9-4856-b95a-3b1ff0c658bd', u'-- %SIPUUID% "%SIPName%" %AIPCompressionAlgorithm% %SIPDirectory% %AIPFilename%'),
+        # compressAIP.py
+        ('4dc2b1d2-acbb-47e7-88ca-570281f3236f', u'-- %AIPCompressionAlgorithm% %AIPCompressionLevel% %SIPDirectory% "%SIPName%" %SIPUUID%'),
+        # emailFailReport.py
+        ('807603e2-9914-46e0-9be4-73d4c073d2e8', u'--unitType="%unitType%" --unitIdentifier="%SIPUUID%" --unitName="%SIPName%"'),
+    )
+
+    for stc, args in tasks:
+        task = StandardTaskConfig.objects.get(id=stc)
+        task.arguments = args
+        task.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0033_dashboardsetting_api_whitelist'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_put_quotes_in_compress_aip_args),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 [flake8]
 exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
 application-import-names = flake8
-ignore = E402, E501
+ignore = E402, E501, E722, E741
 max-line-length = 160
 
 ; Report: $ .tox/flake8/bin/flake8 --isolated -qq --statistics --count --max-line-length=160


### PR DESCRIPTION
This fixes https://github.com/JiscRDSS/rdss-archivematica/issues/98

When the transfer name begins with a dash and is passed as a positional argument, `argparse.ArgumentParser` tries to treat it as an argument name rather than a value

This is *not* a problem for:
* scripts that just use `argv` to process the arguments
* scripts that use named arguments with an equals (e.g. `./myScript.py --name="-mysip"`)

However, it is a problem for:
* scripts that use `ArgumentParser` and named arguments without an equals (e.g. `./myScript --name "-mysip"`)
* scripts that use `ArgumentParser` and positional arguments

I've run database queries to identify the commands that needed changing, and also successfully run a test transfer beginning with a dash.