### PR TITLE
MCPClient: disable capture of output for compressAIP client script

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -136,7 +136,9 @@ Unable to determine if it completed successfully."""
         # Execute command
         command += " " + arguments
         logger.info('<processingCommand>{%s}%s</processingCommand>', gearman_job.unique, command)
-        exitCode, stdOut, stdError = executeOrRun("command", command, sInput, printing=True, env_updates=env_updates)
+        exitCode, stdOut, stdError = executeOrRun(
+            "command", command, sInput, printing=True, env_updates=env_updates,
+            capture_output=False)
         return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
     except OSError:
         logger.exception('Execution failed')

--- a/src/MCPClient/lib/clientScripts/compressAIP.py
+++ b/src/MCPClient/lib/clientScripts/compressAIP.py
@@ -80,7 +80,8 @@ def compress_aip(compression, compression_level, sip_directory, sip_name, sip_uu
         return -1
 
     print('Executing command:', command)
-    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True)
+    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True,
+                                               capture_output=False)
 
     # Add new AIP File
     file_uuid = sip_uuid

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -35,7 +35,7 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, root="archivematica", 
         },
         'root': {  # Everything else
             'handlers': ['console'],
-            'level': 'WARNING',
+            'level': 'DEBUG',
         },
     }
 

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -88,8 +88,10 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[],
             stdOut, stdError = p.communicate(input=stdin_string)
         else:
             # Ignore the stdout and stderr of the subprocess
-            p = subprocess.Popen(command, stdin=stdin_pipe, env=my_env)
-            p.communicate(input=stdin_string)
+            with open(os.devnull, 'w') as devnull:
+                p = subprocess.Popen(command, stdin=stdin_pipe, env=my_env,
+                                     stdout=devnull, stderr=devnull)
+                p.communicate(input=stdin_string)
         # append the output to stderror and stdout
         if printing:
             print(stdOut)

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -51,7 +51,7 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[],
                 if ``command`` is a string.
     env_updates: Dict of changes to apply to the started process' environment.
     capture_output: Whether or not to capture output from the subprocess.
-                    Defaults to `True`.
+                    Defaults to `False`.
     """
     stdError = ""
     stdOut = ""

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -29,7 +29,7 @@ import sys
 
 
 def launchSubProcess(command, stdIn="", printing=True, arguments=[],
-                     env_updates={}, capture_output=True):
+                     env_updates={}, capture_output=False):
     """
     Launches a subprocess using ``command``, where ``command`` is either:
     a) a single string containing a commandline statement, or

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,0 +1,15 @@
+# -*- coding: UTF-8 -*-
+import pytest
+
+import executeOrRunSubProcess as execsub
+
+"""Tests behaviour of capture_output when executing sub processes."""
+def test_capture_output():
+        # Test that stdout and stderr are captured by default
+        ret, std_out, std_err = execsub.launchSubProcess(['ls' , '/tmp'])
+        assert std_out is not '' or std_err is not ''
+        # Test that stdout and stderr are not captured when disabled
+        ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'],
+                                                         capture_output=False)
+        assert std_out is ''
+        assert std_err is''

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -20,6 +20,6 @@ def test_capture_output():
     # Test that stdout and stderr are not captured when `capture_output` is
     # not enabled.
     ret, std_out, std_err = execsub.launchSubProcess(
-        ['ls', '/tmp'], capture_output=True)
+        ['ls', '/tmp'], capture_output=False)
     assert std_out is ''
     assert std_err is ''

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,15 +1,18 @@
 # -*- coding: UTF-8 -*-
-import pytest
 
 import executeOrRunSubProcess as execsub
 
-"""Tests behaviour of capture_output when executing sub processes."""
+
 def test_capture_output():
-        # Test that stdout and stderr are captured by default
-        ret, std_out, std_err = execsub.launchSubProcess(['ls' , '/tmp'])
-        assert std_out is not '' or std_err is not ''
-        # Test that stdout and stderr are not captured when disabled
-        ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'],
-                                                         capture_output=False)
-        assert std_out is ''
-        assert std_err is''
+    """Tests behaviour of capture_output when executing sub processes."""
+
+    # Test that stdout and stderr are not captured by default
+    ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'])
+    assert std_out is ''
+    assert std_err is''
+
+    # Test that stdout and stderr are captured when `capture_output` is
+    # enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=True)
+    assert std_out is not '' or std_err is not ''

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -9,10 +9,17 @@ def test_capture_output():
     # Test that stdout and stderr are not captured by default
     ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'])
     assert std_out is ''
-    assert std_err is''
+    assert std_err is ''
 
     # Test that stdout and stderr are captured when `capture_output` is
     # enabled.
     ret, std_out, std_err = execsub.launchSubProcess(
         ['ls', '/tmp'], capture_output=True)
     assert std_out is not '' or std_err is not ''
+
+    # Test that stdout and stderr are not captured when `capture_output` is
+    # not enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=True)
+    assert std_out is ''
+    assert std_err is ''


### PR DESCRIPTION
The task in #39 is to disable the capture of output specifically for the `compressAIP` function in `compressAIP.py` in the MCP client scripts. However, in looking at the code it became apparent that the best place to do this is actually in the `executeOrRunSubprocess.py` library in `archivematicaCommon`.

I've therefore added a `capture_output` parameter to the functions in `executeOrRunSubprocess.py`. This is set to True by default so existing behaviour is maintained. However the compressAIP script sets `capture_output` to `False`, thereby disabling the capture of stdout and stderr for this specific task.

I've also included a `py.test` unit test to demonstrate and prove the expected functionality.

@jhsimpson and @sevein I'd appreciate your feedback on this approach, in light of the work that is in progress or planned upstream.