### PR TITLE
Dashboard: show job status instead of id

### DIFF
--- a/src/dashboard/src/main/templatetags/job_status.py
+++ b/src/dashboard/src/main/templatetags/job_status.py
@@ -1,0 +1,27 @@
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.template import Library
+
+from main.models import Job
+
+register = Library()
+
+
+@register.filter
+def job_status(status_id):
+    return dict(Job.STATUS).get(status_id)

--- a/src/dashboard/src/templates/ingest/microservices.html
+++ b/src/dashboard/src/templates/ingest/microservices.html
@@ -1,6 +1,7 @@
 {% extends "layout_fluid.html" %}
 {% load breadcrumb %}
 {% load i18n %}
+{% load job_status %}
 
 {% block content %}
   <div class="row">
@@ -26,7 +27,7 @@
           {{ item.grouper }}<br />
           <ul>
             {% for i in item.list %}
-              <li><strong>{{ i.jobtype }}:</strong> {{ i.currentstep }}</li>
+              <li><strong>{{ i.jobtype }}:</strong> {{ i.currentstep|job_status }}</li>
             {% endfor %}
           </ul>
         </div>

--- a/src/dashboard/src/templates/transfer/microservices.html
+++ b/src/dashboard/src/templates/transfer/microservices.html
@@ -1,6 +1,7 @@
 {% extends "layout_fluid.html" %}
 {% load breadcrumb %}
 {% load i18n %}
+{% load job_status %}
 
 {% block content %}
   <div class="row">
@@ -27,7 +28,7 @@
           {{ item.grouper }}<br />
           <ul>
             {% for i in item.list %}
-              <li><strong>{{ i.jobtype }}:</strong> {{ i.currentstep }}</li>
+              <li><strong>{{ i.jobtype }}:</strong> {{ i.currentstep|job_status }}</li>
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
At some point in the development of AM17 we converted the status of a job (used in a few models) into a choice set indexed with integers. This template was left behind so it was showing the integer instead of the string.

The solution is based on a custom Django filter. I tried to use a new method property added to the model but it didn't work because it seems to be not a feature available in Django 1.8.

- https://github.com/JiscRDSS/rdss-archivematica/issues/91
- [RDSSARK-338](https://jiscdev.atlassian.net/browse/RDSSARK-338)