### PR TITLE
MCPClient: fix email from header

### DIFF
--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -24,6 +24,7 @@ from lxml import etree
 import sys
 
 import django
+from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.db import connection
@@ -49,15 +50,15 @@ def get_emails_from_dashboard_users():
     return User.objects.filter(is_active=True).values_list('email', flat=True).exclude(email__in=['demo@example.com', ''])
 
 
-def send_email(subject, to, efrom, content):
+def send_email(subject, to, content):
     try:
         logger.info('Sending email...')
         return send_mail(
             subject=subject,
             message='Please see the attached HTML document',
-            html_message=content,
-            from_email=efrom,
+            from_email=mcpclient_settings.DEFAULT_FROM_EMAIL,
             recipient_list=to,
+            html_message=content,
         )
     except:
         logger.exception('Report email was not delivered')
@@ -196,11 +197,10 @@ if __name__ == '__main__':
         logger.error('Nobody to send it to. Please add users with valid email addresses in the dashboard.')
         sys.exit(1)
     subject = 'Archivematica Fail Report for %s: %s-%s' % (args.unit_type, args.unit_name, args.unit_uuid)
-    efrom = 'ArchivematicaSystem@archivematica.org'
 
     # Generate report in HTML and send it by email
     content = get_content_for(args.unit_type, args.unit_name, args.unit_uuid, html=True)
-    send_email(subject, to, efrom, content)
+    send_email(subject, to, content)
 
     if args.stdout:
         print(content)

--- a/src/MCPClient/lib/clientScripts/normalizeReport.py
+++ b/src/MCPClient/lib/clientScripts/normalizeReport.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 
 import django
+from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.template import Context, Template
@@ -154,9 +155,9 @@ def report(uuid):
         send_mail(
             subject='Normalization failure report for {} ({})'.format(ctxdict['name'], ctxdict['uuid']),
             message='Please see the attached HTML document',
-            html_message=html_message,
-            from_email='Archivematica <ArchivematicaSystem@archivematica.org>',
+            from_email=mcpclient_settings.DEFAULT_FROM_EMAIL,
             recipient_list=recipient_list,
+            html_message=html_message,
         )
     except:
         logger.exception('Report email was not delivered')

--- a/src/MCPClient/tests/test_email_fail_report.py
+++ b/src/MCPClient/tests/test_email_fail_report.py
@@ -23,12 +23,14 @@ def fake_send_email_with_exception(subject, message, from_email, recipient_list,
     raise SMTPException('Something really bad happened!')
 
 
-def test_send_email_ok():
-    total = send_email("Foobar", ["to@domain.tld"], "from@domain.tld",
-                       "<html>...</html>")
+def test_send_email_ok(settings):
+    settings.DEFAULT_FROM_EMAIL = "foo@bar.tld"
+    total = send_email("Foobar", ["to@domain.tld"], "<html>...</html>")
+
     assert total == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "Foobar"
+    assert mail.outbox[0].from_email == "foo@bar.tld"
     assert mail.outbox[0].to == ["to@domain.tld"]
     assert mail.outbox[0].body == "Please see the attached HTML document"
     assert len(mail.outbox[0].alternatives) == 1
@@ -39,5 +41,4 @@ def test_send_email_err(monkeypatch):
     monkeypatch.setattr('django.core.mail.send_mail.func_code',
                         fake_send_email_with_exception.func_code)
     with pytest.raises(SMTPException):
-        send_email("Foobar", ["to@domain.tld"], "from@domain.tld",
-                   "<html>...</html>")
+        send_email("Foobar", ["to@domain.tld"], "<html>...</html>")


### PR DESCRIPTION
Honour `DEFAULT_FROM_EMAIL`. `send_mail` requires a `from_email` argument so I need to look up the setting manually. An alternative would be to use the `email_user(subject, message, from_email=None, **kwargs)` method of the User which honours the setting but it would also require more changes.

- https://github.com/JiscRDSS/rdss-archivematica/issues/110
- [RDSSARK-348](https://jiscdev.atlassian.net/browse/RDSSARK-348)