### PR TITLE
MCPClient: add version and agent code to docker image

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:14.04
 
+ARG ARCHIVEMATICA_VERSION
+ARG AGENT_CODE
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE settings.common
@@ -84,6 +86,11 @@ ADD archivematicaCommon/lib/externals/fido/archivematica_format_extensions.xml /
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \
 	&& useradd --uid 333 --gid 333 --system archivematica
+
+RUN mkdir -p /etc/archivematica && (echo "---"; \
+	 echo "version: $ARCHIVEMATICA_VERSION"; \
+	 echo "agent_code: $AGENT_CODE";) \
+		> /etc/archivematica/version.yml
 
 USER archivematica
 

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -16,6 +16,7 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import StringIO
+import yaml
 
 from appconfig import Config
 import email_settings
@@ -187,3 +188,7 @@ CLAMAV_SERVER = config.get('clamav_server')
 
 # Apply email settings
 globals().update(email_settings.get_settings(config))
+
+doc = yaml.safe_load(open('/etc/archivematica/version.yml'))
+ARCHIVEMATICA_VERSION = doc.get('version')
+AGENT_CODE = doc.get('agent_code')


### PR DESCRIPTION
We recently changed the Dashboard to read from a `version.yml` file so that we could specify a different version for the JiscRDSS fork than "vanilla" Archivematica. 

However, we also need to make this change for the MCPClient. Without it, the Index AIP task fails because the `indexAIP.py` script indirectly calls `version.get_version()`, and we get this error:

```Traceback (most recent call last):
  File "/src/MCPClient/lib/clientScripts/indexAIP.py", line 120, in <module>
    sys.exit(index_aip())
  File "/src/MCPClient/lib/clientScripts/indexAIP.py", line 108, in index_aip
    sipName=sip_name,
  File "/src/archivematicaCommon/lib/elasticSearchFunctions.py", line 481, in index_files
    identifiers=identifiers
  File "/src/archivematicaCommon/lib/elasticSearchFunctions.py", line 535, in index_mets_file_metadata
    'archivematicaVersion': version.get_version(),
  File "/src/archivematicaCommon/lib/version.py", line 6, in get_version
    return settings.ARCHIVEMATICA_VERSION
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 49, in __getattr__
    return getattr(self._wrapped, name)
AttributeError: 'Settings' object has no attribute 'ARCHIVEMATICA_VERSION'
```
This pull request makes this change, using the same approach as we used for the Dashboard. It's now working as expected in my local development environment.