### PR TITLE
MCPClient: single-threaded implementation

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -31,4 +31,4 @@ RUN mkdir -p /etc/archivematica && (echo "---"; \
 
 USER archivematica
 
-ENTRYPOINT /src/MCPClient/lib/archivematicaClient.py
+ENTRYPOINT ["/src/MCPClient/lib/archivematicaClient.py"]

--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -31,4 +31,4 @@ RUN mkdir -p /etc/archivematica && (echo "---"; \
 
 USER archivematica
 
-ENTRYPOINT ["/src/MCPClient/lib/archivematicaClient.py"]
+ENTRYPOINT ["/src/MCPClient/lib/archivematicaSingleClient.py"]

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python2
 
-"""Archivematica Client (Gearman Worker)
+"""Archivematica Client (multi-threaded Gearman Worker).
 
-This executable does the following.
+This executable does the following:
 
 1. Loads tasks from config. Loads a list of performable tasks (client scripts)
    from a config file (typically that in lib/archivematicaClientModules) and
@@ -43,174 +43,35 @@ arguments to pass to the client script. The following then happens.
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-# @package Archivematica
-# @subpackage archivematicaClient
-# @author Joseph Perry <joseph@artefactual.com>
-
-import ConfigParser
-import cPickle
 import logging
-import os
-from socket import gethostname
 import threading
 import time
-import traceback
 
 import django
-django.setup()
 from django.conf import settings as django_settings
-from django_mysqlpool import auto_close_db
 import gearman
 
-from main.models import Task
-from databaseFunctions import getUTCDate
-from executeOrRunSubProcess import executeOrRun
+from detect_cores import detect_cores
+from modules import load_supported_modules
+from worker import get_worker
 
 
 logger = logging.getLogger('archivematica.mcp.client')
 
-replacement_dict = {
-    "%sharedPath%": django_settings.SHARED_DIRECTORY,
-    "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
-    "%clientAssetsDirectory%": django_settings.CLIENT_ASSETS_DIRECTORY,
-}
 
-# This dict will map the names of the client scripts listed in the config file
-# (typically MCPClient/lib/archivematicaClientModules) to the full paths to
-# those scripts on disk.
-supported_modules = {}
+def start_worker(thread_number, gearman_servers):
+    """Run a Gearman worker in this thread.
 
-
-def load_supported_modules_support(client_script, client_script_path):
-    """Replace variables in ``client_script_path`` and confirm that said path
-    is an existent file.
+    The connection with the server will be retried indefinitely.
     """
-    for key2, value2 in replacement_dict.items():
-        client_script_path = client_script_path.replace(key2, value2)
-    if not os.path.isfile(client_script_path):
-        logger.error('Warning! Module can\'t find file, or relies on system'
-                     ' path: {%s} %s', client_script, client_script_path)
-    supported_modules[client_script] = client_script_path + ' '
+    worker = get_worker(gearman_servers, name=thread_number)
 
-
-def load_supported_modules(file):
-    """Populate the global `supported_modules` dict by parsing the MCPClient
-    modules config file (typically MCPClient/lib/archivematicaClientModules).
-    """
-    supported_modules_config = ConfigParser.RawConfigParser()
-    supported_modules_config.read(file)
-    for client_script, client_script_path in supported_modules_config.items(
-            'supportedCommands'):
-        load_supported_modules_support(client_script, client_script_path)
-    if django_settings.LOAD_SUPPORTED_COMMANDS_SPECIAL:
-        for client_script, client_script_path in supported_modules_config.items(
-                'supportedCommandsSpecial'):
-            load_supported_modules_support(client_script, client_script_path)
-
-
-class ProcessGearmanJobError(Exception):
-    pass
-
-
-def _process_gearman_job(gearman_job, gearman_worker):
-    """Process a gearman job/task: return a 3-tuple consisting of a script
-    string (a command-line script with arguments), a task UUID string, and a
-    boolean indicating whether output streams should be captured. Raise a
-    custom exception if the client script is unregistered or if the task has
-    already been started.
-    """
-    # ``client_script`` is a string matching one of the keys (i.e., client
-    # scripts) in the global ``supported_modules`` dict.
-    client_script = gearman_job.task
-    task_uuid = str(gearman_job.unique)
-    logger.info('Executing %s (%s)', client_script, task_uuid)
-    data = cPickle.loads(gearman_job.data)
-    utc_date = getUTCDate()
-    arguments = data['arguments']
-    if isinstance(arguments, unicode):
-        arguments = arguments.encode('utf-8')
-    client_id = gearman_worker.worker_client_id
-    task = Task.objects.get(taskuuid=task_uuid)
-    if task.starttime is not None:
-        raise ProcessGearmanJobError({
-            'exitCode': -1,
-            'stdOut': '',
-            'stdError': 'Detected this task has already started!\n'
-                        'Unable to determine if it completed successfully.'})
-    task.client = client_id
-    task.starttime = utc_date
-    task.save()
-    client_script_full_path = supported_modules.get(client_script)
-    if not client_script_full_path:
-        raise ProcessGearmanJobError({
-            'exitCode': -1,
-            'stdOut': 'Error!',
-            'stdError': 'Error! - Tried to run an unsupported command.'})
-    replacement_dict['%date%'] = utc_date.isoformat()
-    replacement_dict['%jobCreatedDate%'] = data['createdDate']
-    # Replace replacement strings
-    for var, val in replacement_dict.items():
-        # TODO: this seems unneeded because the full path to the client
-        # script can never contain '%date%' or '%jobCreatedDate%' and the
-        # other possible vars have already been replaced.
-        client_script_full_path = client_script_full_path.replace(var, val)
-        arguments = arguments.replace(var, val)
-    arguments = arguments.replace('%taskUUID%', task_uuid)
-    script = client_script_full_path + ' ' + arguments
-    return script, task_uuid
-
-
-def _unexpected_error():
-    logger.exception('Unexpected error')
-    return cPickle.dumps({'exitCode': -1,
-                          'stdOut': '',
-                          'stdError': traceback.format_exc()})
-
-
-@auto_close_db
-def execute_command(gearman_worker, gearman_job):
-    """Execute the command encoded in ``gearman_job`` and return its exit code,
-    standard output and standard error as a pickled dict.
-    """
-    try:
-        script, task_uuid = _process_gearman_job(
-            gearman_job, gearman_worker)
-    except ProcessGearmanJobError as error:
-        return cPickle.dumps(error)
-    except Exception:
-        return _unexpected_error()
-    logger.info('<processingCommand>{%s}%s</processingCommand>',
-                task_uuid, script)
-    try:
-        exit_code, std_out, std_error = executeOrRun(
-            'command', script, stdIn='', printing=True)
-    except OSError:
-        logger.exception('Execution failed')
-        return cPickle.dumps({'exitCode': 1,
-                              'stdOut': 'Archivematica Client Error!',
-                              'stdError': traceback.format_exc()})
-    except Exception:
-        return _unexpected_error()
-    return cPickle.dumps({'exitCode': exit_code,
-                          'stdOut': std_out,
-                          'stdError': std_error})
-
-
-@auto_close_db
-def start_thread(thread_number):
-    """Setup a gearman client, for the thread."""
-    gm_worker = gearman.GearmanWorker([django_settings.GEARMAN_SERVER])
-    host_id = '{}_{}'.format(gethostname(), thread_number)
-    gm_worker.set_client_id(host_id)
-    for client_script in supported_modules:
-        logger.info('Registering: %s', client_script)
-        gm_worker.register_task(client_script, execute_command)
     fail_max_sleep = 30
     fail_sleep = 1
     fail_sleep_incrementor = 2
     while True:
         try:
-            gm_worker.work()
+            worker.work()
         except gearman.errors.ServerUnavailable as inst:
             logger.error('Gearman server is unavailable: %s. Retrying in %d'
                          ' seconds.', inst.args, fail_sleep)
@@ -219,24 +80,47 @@ def start_thread(thread_number):
                 fail_sleep += fail_sleep_incrementor
 
 
-def start_threads(t=1):
-    """Start a processing thread for each core (t=0), or a specified number of
-    threads.
+def start_workers(gearman_servers, workers=1):
+    """Start multiple threaded workers.
+
+    The workers are executed as separate daemonic threads meaning that they are
+    abruptly stopped at shutdown. Their resources may not be released properly.
+    We should consider making them non-daemonic and use a suitable signalling
+    mechanism such as ``threading.Event``.
+
+    The number of workers created is determined by the ``workers`` argument.
+    If ``0`` the function will create as many workers as CPU cores are detected
+    in the operative system.
     """
-    if t == 0:
-        from externals.detectCores import detectCPUs
-        t = detectCPUs()
-    for i in range(t):
-        t = threading.Thread(target=start_thread, args=(i + 1,))
-        t.daemon = True
-        t.start()
+    if workers == 0:
+        workers = detect_cores()
+    for index in range(workers):
+        thread = threading.Thread(target=start_worker, args=(
+            index + 1,
+            gearman_servers))
+        thread.daemon = True
+        thread.start()
 
 
-if __name__ == '__main__':
+def main():
+    """Start multi-threaded MCPClient."""
+    django.setup()
+
+    load_supported_modules(
+        django_settings.CLIENT_MODULES_FILE,
+        django_settings.LOAD_SUPPORTED_COMMANDS_SPECIAL)
+
+    # This call does not block.
+    start_workers(
+        django_settings.GEARMAN_SERVER.split(','),
+        django_settings.NUMBER_OF_TASKS)
+
     try:
-        load_supported_modules(django_settings.CLIENT_MODULES_FILE)
-        start_threads(django_settings.NUMBER_OF_TASKS)
         while True:
             time.sleep(100)
     except (KeyboardInterrupt, SystemExit):
         logger.info('Received keyboard interrupt, quitting threads.')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -1,8 +1,34 @@
 #!/usr/bin/env python2
 
+"""Archivematica Client (Gearman Worker)
+
+This executable does the following.
+
+1. Loads tasks from config. Loads a list of performable tasks (client scripts)
+   from a config file (typically that in lib/archivematicaClientModules) and
+   creates a mapping from names of those tasks (e.g., 'normalize_v1.0') to the
+   full paths of their corresponding (Python or bash) scripts (e.g.,
+   '/src/MCPClient/lib/clientScripts/normalize.py').
+
+2. Registers tasks with Gearman. On multiple threads, create a Gearman worker
+   and register the loaded tasks with the Gearman server, effectively saying
+   "Hey, I can normalize files", etc.
+
+When the MCPServer requests that the MCPClient perform a registered task, the
+MCPClient thread calls ``execute_command``, passing it a job object which has a
+``task`` attribute containing the name of the client script to run, and a
+``data`` attribute whose value is a BLOB that unpickles to a dict containing
+arguments to pass to the client script. The following then happens.
+
+1. The client script is run in a subprocess with the provided arguments.
+
+2. The exit code and output streams are pickled and returned.
+
+"""
+
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -21,164 +47,195 @@
 # @subpackage archivematicaClient
 # @author Joseph Perry <joseph@artefactual.com>
 
-# ~DOC~
-#
-# --- This is the MCP Client---
-# It connects to the MCP server, and informs the server of the tasks it can perform.
-# The server can send a command (matching one of the tasks) for the client to perform.
-# The client will perform that task, and return the exit code and output to the server.
-#
-# For archivematica 0.9 release. Added integration with the transcoder.
-# The server will send the transcoder association pk, and file uuid to run.
-# The client is responsible for running the correct command on the file.
-
 import ConfigParser
 import cPickle
-import gearman
 import logging
 import os
-import time
 from socket import gethostname
 import threading
+import time
 import traceback
 
 import django
 django.setup()
-
 from django.conf import settings as django_settings
+from django_mysqlpool import auto_close_db
+import gearman
 
 from main.models import Task
-
-from databaseFunctions import auto_close_db, getUTCDate
+from databaseFunctions import getUTCDate
 from executeOrRunSubProcess import executeOrRun
 
 
 logger = logging.getLogger('archivematica.mcp.client')
 
-replacementDic = {
+replacement_dict = {
     "%sharedPath%": django_settings.SHARED_DIRECTORY,
     "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
     "%clientAssetsDirectory%": django_settings.CLIENT_ASSETS_DIRECTORY,
 }
-supportedModules = {}
+
+# This dict will map the names of the client scripts listed in the config file
+# (typically MCPClient/lib/archivematicaClientModules) to the full paths to
+# those scripts on disk.
+supported_modules = {}
 
 
-def loadSupportedModulesSupport(key, value):
-    for key2, value2 in replacementDic.items():
-        value = value.replace(key2, value2)
-    if not os.path.isfile(value):
-        logger.error("Warning! Module can't find file, or relies on system path: {%s} %s", key, value)
-    supportedModules[key] = value + " "
+def load_supported_modules_support(client_script, client_script_path):
+    """Replace variables in ``client_script_path`` and confirm that said path
+    is an existent file.
+    """
+    for key2, value2 in replacement_dict.items():
+        client_script_path = client_script_path.replace(key2, value2)
+    if not os.path.isfile(client_script_path):
+        logger.error('Warning! Module can\'t find file, or relies on system'
+                     ' path: {%s} %s', client_script, client_script_path)
+    supported_modules[client_script] = client_script_path + ' '
 
 
-def loadSupportedModules(file):
-    supportedModulesConfig = ConfigParser.RawConfigParser()
-    supportedModulesConfig.read(file)
-    for key, value in supportedModulesConfig.items('supportedCommands'):
-        loadSupportedModulesSupport(key, value)
-
+def load_supported_modules(file):
+    """Populate the global `supported_modules` dict by parsing the MCPClient
+    modules config file (typically MCPClient/lib/archivematicaClientModules).
+    """
+    supported_modules_config = ConfigParser.RawConfigParser()
+    supported_modules_config.read(file)
+    for client_script, client_script_path in supported_modules_config.items(
+            'supportedCommands'):
+        load_supported_modules_support(client_script, client_script_path)
     if django_settings.LOAD_SUPPORTED_COMMANDS_SPECIAL:
-        for key, value in supportedModulesConfig.items('supportedCommandsSpecial'):
-            loadSupportedModulesSupport(key, value)
+        for client_script, client_script_path in supported_modules_config.items(
+                'supportedCommandsSpecial'):
+            load_supported_modules_support(client_script, client_script_path)
+
+
+class ProcessGearmanJobError(Exception):
+    pass
+
+
+def _process_gearman_job(gearman_job, gearman_worker):
+    """Process a gearman job/task: return a 3-tuple consisting of a script
+    string (a command-line script with arguments), a task UUID string, and a
+    boolean indicating whether output streams should be captured. Raise a
+    custom exception if the client script is unregistered or if the task has
+    already been started.
+    """
+    # ``client_script`` is a string matching one of the keys (i.e., client
+    # scripts) in the global ``supported_modules`` dict.
+    client_script = gearman_job.task
+    task_uuid = str(gearman_job.unique)
+    logger.info('Executing %s (%s)', client_script, task_uuid)
+    data = cPickle.loads(gearman_job.data)
+    utc_date = getUTCDate()
+    arguments = data['arguments']
+    if isinstance(arguments, unicode):
+        arguments = arguments.encode('utf-8')
+    client_id = gearman_worker.worker_client_id
+    task = Task.objects.get(taskuuid=task_uuid)
+    if task.starttime is not None:
+        raise ProcessGearmanJobError({
+            'exitCode': -1,
+            'stdOut': '',
+            'stdError': 'Detected this task has already started!\n'
+                        'Unable to determine if it completed successfully.'})
+    task.client = client_id
+    task.starttime = utc_date
+    task.save()
+    client_script_full_path = supported_modules.get(client_script)
+    if not client_script_full_path:
+        raise ProcessGearmanJobError({
+            'exitCode': -1,
+            'stdOut': 'Error!',
+            'stdError': 'Error! - Tried to run an unsupported command.'})
+    replacement_dict['%date%'] = utc_date.isoformat()
+    replacement_dict['%jobCreatedDate%'] = data['createdDate']
+    # Replace replacement strings
+    for var, val in replacement_dict.items():
+        # TODO: this seems unneeded because the full path to the client
+        # script can never contain '%date%' or '%jobCreatedDate%' and the
+        # other possible vars have already been replaced.
+        client_script_full_path = client_script_full_path.replace(var, val)
+        arguments = arguments.replace(var, val)
+    arguments = arguments.replace('%taskUUID%', task_uuid)
+    script = client_script_full_path + ' ' + arguments
+    return script, task_uuid
+
+
+def _unexpected_error():
+    logger.exception('Unexpected error')
+    return cPickle.dumps({'exitCode': -1,
+                          'stdOut': '',
+                          'stdError': traceback.format_exc()})
 
 
 @auto_close_db
-def executeCommand(gearman_worker, gearman_job):
+def execute_command(gearman_worker, gearman_job):
+    """Execute the command encoded in ``gearman_job`` and return its exit code,
+    standard output and standard error as a pickled dict.
+    """
     try:
-        execute = gearman_job.task
-        logger.info('Executing %s (%s)', execute, gearman_job.unique)
-        data = cPickle.loads(gearman_job.data)
-        utcDate = getUTCDate()
-        arguments = data["arguments"]  # .encode("utf-8")
-        if isinstance(arguments, unicode):
-            arguments = arguments.encode("utf-8")
-
-        sInput = ""
-        clientID = gearman_worker.worker_client_id
-
-        task = Task.objects.get(taskuuid=gearman_job.unique)
-        if task.starttime is not None:
-            exitCode = -1
-            stdOut = ""
-            stdError = """Detected this task has already started!
-Unable to determine if it completed successfully."""
-            return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
-        else:
-            task.client = clientID
-            task.starttime = utcDate
-            task.save()
-
-        if execute not in supportedModules:
-            output = ["Error!", "Error! - Tried to run and unsupported command."]
-            exitCode = -1
-            return cPickle.dumps({"exitCode": exitCode, "stdOut": output[0], "stdError": output[1]})
-        command = supportedModules[execute]
-
-        replacementDic["%date%"] = utcDate.isoformat()
-        replacementDic["%jobCreatedDate%"] = data["createdDate"]
-        # Replace replacement strings
-        for key in replacementDic.keys():
-            command = command.replace(key, replacementDic[key])
-            arguments = arguments.replace(key, replacementDic[key])
-
-        key = "%taskUUID%"
-        value = gearman_job.unique.__str__()
-        arguments = arguments.replace(key, value)
-
-        # Execute command
-        command += " " + arguments
-        logger.info('<processingCommand>{%s}%s</processingCommand>', gearman_job.unique, command)
-        exitCode, stdOut, stdError = executeOrRun("command", command, sInput, printing=True)
-        return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
+        script, task_uuid = _process_gearman_job(
+            gearman_job, gearman_worker)
+    except ProcessGearmanJobError as error:
+        return cPickle.dumps(error)
+    except Exception:
+        return _unexpected_error()
+    logger.info('<processingCommand>{%s}%s</processingCommand>',
+                task_uuid, script)
+    try:
+        exit_code, std_out, std_error = executeOrRun(
+            'command', script, stdIn='', printing=True)
     except OSError:
         logger.exception('Execution failed')
-        output = ["Archivematica Client Error!", traceback.format_exc()]
-        exitCode = 1
-        return cPickle.dumps({"exitCode": exitCode, "stdOut": output[0], "stdError": output[1]})
+        return cPickle.dumps({'exitCode': 1,
+                              'stdOut': 'Archivematica Client Error!',
+                              'stdError': traceback.format_exc()})
     except Exception:
-        logger.exception('Unexpected error')
-        output = ["", traceback.format_exc()]
-        return cPickle.dumps({"exitCode": -1, "stdOut": output[0], "stdError": output[1]})
+        return _unexpected_error()
+    return cPickle.dumps({'exitCode': exit_code,
+                          'stdOut': std_out,
+                          'stdError': std_error})
 
 
 @auto_close_db
-def startThread(threadNumber):
+def start_thread(thread_number):
     """Setup a gearman client, for the thread."""
     gm_worker = gearman.GearmanWorker([django_settings.GEARMAN_SERVER])
-    hostID = gethostname() + "_" + threadNumber.__str__()
-    gm_worker.set_client_id(hostID)
-    for key in supportedModules.keys():
-        logger.info('Registering: %s', key)
-        gm_worker.register_task(key, executeCommand)
-
-    failMaxSleep = 30
-    failSleep = 1
-    failSleepIncrementor = 2
+    host_id = '{}_{}'.format(gethostname(), thread_number)
+    gm_worker.set_client_id(host_id)
+    for client_script in supported_modules:
+        logger.info('Registering: %s', client_script)
+        gm_worker.register_task(client_script, execute_command)
+    fail_max_sleep = 30
+    fail_sleep = 1
+    fail_sleep_incrementor = 2
     while True:
         try:
             gm_worker.work()
         except gearman.errors.ServerUnavailable as inst:
-            logger.error('Gearman server is unavailable: %s. Retrying in %d seconds.', inst.args, failSleep)
-            time.sleep(failSleep)
-            if failSleep < failMaxSleep:
-                failSleep += failSleepIncrementor
+            logger.error('Gearman server is unavailable: %s. Retrying in %d'
+                         ' seconds.', inst.args, fail_sleep)
+            time.sleep(fail_sleep)
+            if fail_sleep < fail_max_sleep:
+                fail_sleep += fail_sleep_incrementor
 
 
-def startThreads(t=1):
-    """Start a processing thread for each core (t=0), or a specified number of threads."""
+def start_threads(t=1):
+    """Start a processing thread for each core (t=0), or a specified number of
+    threads.
+    """
     if t == 0:
         from externals.detectCores import detectCPUs
         t = detectCPUs()
     for i in range(t):
-        t = threading.Thread(target=startThread, args=(i + 1, ))
+        t = threading.Thread(target=start_thread, args=(i + 1,))
         t.daemon = True
         t.start()
 
 
 if __name__ == '__main__':
     try:
-        loadSupportedModules(django_settings.CLIENT_MODULES_FILE)
-        startThreads(django_settings.NUMBER_OF_TASKS)
+        load_supported_modules(django_settings.CLIENT_MODULES_FILE)
+        start_threads(django_settings.NUMBER_OF_TASKS)
         while True:
             time.sleep(100)
     except (KeyboardInterrupt, SystemExit):

--- a/src/MCPClient/lib/archivematicaSingleClient.py
+++ b/src/MCPClient/lib/archivematicaSingleClient.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python2
+
+"""Archivematica Client (single-threaded Gearman Worker).
+
+This executable does the following:
+
+1. Loads tasks from config. Loads a list of performable tasks (client scripts)
+   from a config file (typically that in lib/archivematicaClientModules) and
+   creates a mapping from names of those tasks (e.g., 'normalize_v1.0') to the
+   full paths of their corresponding (Python or bash) scripts (e.g.,
+   '/src/MCPClient/lib/clientScripts/normalize.py').
+
+2. Registers tasks with Gearman.  Create a Gearman worker and register the
+   loaded tasks with the Gearman server, effectively saying "Hey, I can
+   normalize files", etc.
+
+When the MCPServer requests that the MCPClient perform a registered task, the
+MCPClient thread calls ``execute_command``, passing it a job object which has a
+``task`` attribute containing the name of the client script to run, and a
+``data`` attribute whose value is a BLOB that unpickles to a dict containing
+arguments to pass to the client script. The following then happens.
+
+1. The client script is run in a subprocess with the provided arguments.
+
+2. The exit code and output streams are pickled and returned.
+
+"""
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import signal
+
+import django
+from django.conf import settings as django_settings
+import gearman
+
+from modules import load_supported_modules
+from worker import get_worker
+
+
+logger = logging.getLogger('archivematica.mcp.client')
+
+# The worker object needs to be shared with the thread that runs the signal
+# handler so it can stop it.
+worker = None
+
+# Dictionary of signals indexed by the signal ID. This is here so we can log the
+# signal name instead of the ID when a signal is received.
+SIGNALS = dict((getattr(signal, n), n)
+               for n in dir(signal) if n.startswith('SIG') and '_' not in n)
+
+
+def start_worker(gearman_servers):
+    """Create worker and loop indifinitely to complete Gearman jobs."""
+    global worker
+    worker = get_worker(gearman_servers)
+
+    try:
+        logger.info('Ready to accept jobs.')
+        worker.work()  # This is going to block.
+    except gearman.errors.ServerUnavailable as err:
+        logger.error('Gearman server is unavailable - %s', err)
+    except (KeyboardInterrupt, SystemExit):
+        logger.info('Shutting down!')
+
+
+def quit(signo, _frame):
+    """SIGTERM and SIGINT signal handler.
+
+    It closes the current connections with the Gearman server in order to
+    interrupt the worker loop.
+    """
+    logger.info("Interrupted by signal %s, shutting down." % SIGNALS[signo])
+    worker.shutdown()
+
+
+def main():
+    """Start single-threaded MCPClient."""
+    # Set up quit signal handler.
+    signal.signal(signal.SIGTERM, quit)
+    signal.signal(signal.SIGINT, quit)
+
+    django.setup()
+    gearman_servers = django_settings.GEARMAN_SERVER.split(',')
+
+    load_supported_modules(django_settings.CLIENT_MODULES_FILE)
+
+    # This call blocks.
+    start_worker(gearman_servers)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/MCPClient/lib/detect_cores.py
+++ b/src/MCPClient/lib/detect_cores.py
@@ -1,15 +1,17 @@
-#!/usr/bin/env python2
-# Author Bruce Eckel (www.BruceEckel.com)
-# Source http://www.artima.com/weblogs/viewpost.jsp?thread=230001
+"""Detect CPU cores.
 
-from __future__ import print_function
+This module contains a function that helps to determine the number of CPU cores
+available in the system.
+
+Inspired by code shared by Bruce Eckel (www.BruceEckel.com) found at
+http://www.artima.com/weblogs/viewpost.jsp?thread=230001.
+"""
+
 import os
 
 
-def detectCPUs():
-    """
-    Detects the number of CPUs on a system. Cribbed from pp.
-    """
+def detect_cores():
+    """Detect the number of CPU cores on a system."""
     # Linux, Unix and MacOS:
     if hasattr(os, "sysconf"):
         if "SC_NPROCESSORS_ONLN" in os.sysconf_names:  # Linux & Unix:
@@ -23,7 +25,3 @@ def detectCPUs():
     if ncpus > 0:
         return ncpus
     return 1  # Default
-
-
-if __name__ == '__main__':
-    print(detectCPUs())

--- a/src/MCPClient/lib/modules.py
+++ b/src/MCPClient/lib/modules.py
@@ -1,0 +1,51 @@
+"""Modules are good for you."""
+
+from ConfigParser import RawConfigParser
+import logging
+import os
+
+from django.conf import settings as django_settings
+
+
+logger = logging.getLogger('archivematica.mcp.client')
+
+
+# This dict will map the names of the client scripts listed in the config file
+# (typically MCPClient/lib/archivematicaClientModules) to the full paths to
+# those scripts on disk.
+supported_modules = {}
+
+
+replacement_dict = {
+    "%sharedPath%": django_settings.SHARED_DIRECTORY,
+    "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
+}
+
+
+def load_supported_modules_support(client_script, client_script_path):
+    """Replace variables in ``client_script_path`` and confirm path."""
+    for key, value in replacement_dict.items():
+        client_script_path = client_script_path.replace(key, value)
+
+    if not os.path.isfile(client_script_path):
+        logger.error('Warning! Module can\'t find file, or relies on system'
+                     ' path: {%s} %s', client_script, client_script_path)
+    supported_modules[client_script] = client_script_path + ' '
+
+
+def load_supported_modules(file, load_special_modules=True):
+    """Populate the global `supported_modules` dict.
+
+    The dictionary is populatede by parsing the MCPClient modules config file
+    (typically MCPClient/lib/archivematicaClientModules).
+    """
+    supported_modules_config = RawConfigParser()
+    supported_modules_config.read(file)
+    for client_script, client_script_path in supported_modules_config.items(
+            'supportedCommands'):
+        load_supported_modules_support(client_script, client_script_path)
+    if not load_special_modules:
+        return
+    for client_script, client_script_path in supported_modules_config.items(
+            'supportedCommandsSpecial'):
+        load_supported_modules_support(client_script, client_script_path)

--- a/src/MCPClient/lib/worker.py
+++ b/src/MCPClient/lib/worker.py
@@ -1,0 +1,149 @@
+"""Provide functionality to set up workers and run Archivematica commands."""
+
+import cPickle
+import logging
+from socket import gethostname
+import traceback
+
+from django.conf import settings as django_settings
+import gearman
+
+from main.models import Task
+from databaseFunctions import auto_close_db, getUTCDate as get_utc_date
+from executeOrRunSubProcess import executeOrRun as execute_or_run
+
+from modules import supported_modules
+
+
+logger = logging.getLogger('archivematica.mcp.client')
+
+
+replacement_dict = {
+    "%sharedPath%": django_settings.SHARED_DIRECTORY,
+    "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
+}
+
+
+class ProcessGearmanJobError(Exception):
+    """ProcessGearmanJobError is an error occurred while executing a command."""
+
+    def pickle(self):
+        """Serialize error."""
+        return _serialize_job_response(**self.args)
+
+
+def _execute_command(gearman_job, gearman_worker):
+    """Execute MCPClient supported module or command.
+
+    Process a Gearman job/task: return a 2-tuple consisting of a script
+    string (a command-line script with arguments) and a task UUID string. Raise
+    a custom exception if the client script is unregistered or if the task has
+    already been started.
+    """
+    # ``client_script`` is a string matching one of the keys (i.e., client
+    # scripts) in the global ``supported_modules`` dict.
+    client_script = gearman_job.task
+    task_uuid = str(gearman_job.unique)
+    logger.info('Executing %s (%s)', client_script, task_uuid)
+    data = cPickle.loads(gearman_job.data)
+    utc_date = get_utc_date()
+    arguments = data['arguments']
+    if isinstance(arguments, unicode):
+        arguments = arguments.encode('utf-8')
+    client_id = gearman_worker.worker_client_id
+    task = Task.objects.get(taskuuid=task_uuid)
+    if task.starttime is not None:
+        raise ProcessGearmanJobError({
+            'exit_code': -1,
+            'stdout': '',
+            'stderr': 'Detected this task has already started!\n'
+                      'Unable to determine if it completed successfully.'})
+    task.client = client_id
+    task.starttime = utc_date
+    task.save()
+    client_script_full_path = supported_modules.get(client_script)
+    if not client_script_full_path:
+        raise ProcessGearmanJobError({
+            'exit_code': -1,
+            'stdout': 'Error!',
+            'stderr': 'Error! - Tried to run an unsupported command.'})
+    replacement_dict['%date%'] = utc_date.isoformat()
+    replacement_dict['%jobCreatedDate%'] = data['createdDate']
+    # Replace replacement strings
+    for var, val in replacement_dict.items():
+        # TODO: this seems unneeded because the full path to the client
+        # script can never contain '%date%' or '%jobCreatedDate%' and the
+        # other possible vars have already been replaced.
+        client_script_full_path = client_script_full_path.replace(var, val)
+        arguments = arguments.replace(var, val)
+    arguments = arguments.replace('%taskUUID%', task_uuid)
+    script = client_script_full_path + ' ' + arguments
+    return script, task_uuid
+
+
+def _unexpected_error():
+    logger.exception('Unexpected error')
+    return _serialize_job_response(-1, '', traceback.format_exc())
+
+
+def _serialize_job_response(exit_code, stdout, stderr):
+    """Serialize job response.
+
+    Do not change this unless MCPServer is updated accordingly!
+    """
+    return cPickle.dumps({'exitCode': exit_code,
+                          'stdOut': stdout,
+                          'stdError': stderr})
+
+
+@auto_close_db
+def process_gearman_job(gearman_worker, gearman_job):
+    """Run a job requested by Gearman.
+
+    This function is executed by GearmanWorker when a job is assigned to this
+    worker. It executes the command encoded in ``gearman_job`` and returns its
+    exit code, standard output and standard error as a pickled dict.
+    """
+    try:
+        script, task_uuid = _execute_command(
+            gearman_job, gearman_worker)
+    except ProcessGearmanJobError as error:
+        return error.pickle()
+    except Exception:
+        return _unexpected_error()
+    logger.info('<processingCommand>{%s}%s</processingCommand>',
+                task_uuid, script)
+    try:
+        exit_code, std_out, std_error = execute_or_run(
+            'command', script, stdIn='', printing=True)
+    except OSError:
+        logger.exception('Execution failed')
+        return _serialize_job_response(1, 'Archivematica Client Error!',
+                                       traceback.format_exc())
+    except Exception:
+        return _unexpected_error()
+    return _serialize_job_response(exit_code, std_out, std_error)
+
+
+def get_worker(gearman_servers, name=None):
+    """Set up Gearman worker object."""
+    worker = gearman.GearmanWorker(gearman_servers)
+
+    # This sets the worker ID in a job server so monitoring and reporting
+    # commands can uniquely identify the various workers, and different
+    # connections to job servers from the same worker.
+    client_id = gethostname()
+    if name is not None:
+        client_id = '{}_{}'.format(client_id, name)
+    worker.set_client_id(gethostname())
+
+    # Notify the Gearman server that this worker is available to perform the
+    # functions that we've encoded in `supported_modules`. The worker will be
+    # put on a list to be woken up whenever the job server receives a job for
+    # these functions (modules).
+    for client_script in supported_modules:
+        logger.info('Registering module %s in worker %s.',
+                    client_script, client_id)
+        worker.register_task(client_script, process_gearman_job)
+
+    return worker


### PR DESCRIPTION
[RDSSARK-374](https://jiscdev.atlassian.net/browse/RDSSARK-374)

This pull request introduces a simplified version of MCPClient where threaded workers are replaced by a single worker loop in the main thread. This loop is now forced to exit by a signal handler `quit` when `SIGINT` or `SIGTERM` signals are received.

This implementation forces the worker to exit immediately which is potentially better than having ECS killing it after the 30 seconds timeout is exceeded. This causes the running jobs to stop and Gearman will eventually schedule them to the next available worker.