### PR TITLE
Configurable timeouts

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -8,6 +8,7 @@ import requests
 
 import django
 django.setup()
+from django.conf import settings as mcpclient_settings
 # dashboard
 from main import models
 
@@ -15,8 +16,6 @@ from main import models
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 import storageService as storage_service
-
-from django.conf import settings as mcpclient_settings
 
 logger = get_script_logger("archivematica.mcp.client.post_store_aip_hook")
 
@@ -55,7 +54,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     url = archivesspace_url + '/users/' + config['user'] + '/login'
     params = {'password': config['passwd']}
     logger.debug('Log in to ArchivesSpace URL: %s', url)
-    response = requests.post(url, params=params, timeout=120)
+    response = requests.post(url, params=params, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     logger.debug('Response: %s %s', response, response.content)
     session_id = response.json()['session']
     headers = {'X-ArchivesSpace-Session': session_id}
@@ -63,7 +62,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     # Get Digital Object from ArchivesSpace
     url = archivesspace_url + digital_object.remoteid
     logger.debug('Get Digital Object info URL: %s', url)
-    response = requests.get(url, headers=headers, timeout=120)
+    response = requests.get(url, headers=headers, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     logger.debug('Response: %s %s', response, response.content)
     body = response.json()
 
@@ -77,7 +76,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     }
     body['file_versions'].append(file_version)
     logger.debug('Modified Digital Object: %s', body)
-    response = requests.post(url, headers=headers, json=body, timeout=120)
+    response = requests.post(url, headers=headers, json=body, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     print('Update response:', response, response.content)
     logger.debug('Response: %s %s', response, response.content)
     if response.status_code != 200:

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -37,6 +37,7 @@ import requests
 
 import django
 django.setup()
+from django.conf import settings as mcpclient_settings
 # dashboard
 import main.models as models
 
@@ -207,7 +208,7 @@ def start(data):
     auth = requests.auth.HTTPBasicAuth(data.email, data.password)
 
     # Disable redirects: AtoM returns 302 instead of 202, but Location header field is valid
-    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=120)
+    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
 
     # response.{content,headers,status_code}
     log("> Response code: %s" % response.status_code)

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -39,6 +39,8 @@ CONFIG_MAPPING = {
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
+    'storage_service_client_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'agentarchives_client_timeout': {'section': 'MCPClient', 'option': 'agentarchives_client_timeout', 'type': 'float'},
 
     # [antivirus]
     'clamav_server': {'section': 'MCPClient', 'option': 'clamav_server', 'type': 'string'},
@@ -79,6 +81,8 @@ temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
 clamav_pass_by_reference = False
+storage_service_client_timeout = 86400
+agentarchives_client_timeout = 300
 clamav_client_timeout = 600
 clamav_client_backend = clamdscanner    ; Options: clamdscanner or clamscanner
 clamav_client_max_file_size = 42        ; MB
@@ -199,6 +203,8 @@ REMOVABLE_FILES = config.get('removable_files')
 TEMP_DIRECTORY = config.get('temp_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
+STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 CLAMAV_SERVER = config.get('clamav_server')
 CLAMAV_PASS_BY_REFERENCE = config.get('clamav_pass_by_reference')
 CLAMAV_CLIENT_TIMEOUT = config.get('clamav_client_timeout')

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -7,7 +7,7 @@ import requests
 from requests.auth import AuthBase
 import urllib
 
-from django.conf import settings
+from django.conf import settings as django_settings
 
 # archivematicaCommon
 from archivematicaFunctions import get_setting
@@ -56,7 +56,7 @@ def _storage_service_url():
     return storage_service_url
 
 
-def _storage_api_session(timeout=5):
+def _storage_api_session(timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT):
     """Return a requests.Session with a customized adapter with timeout support."""
     class HTTPAdapterWithTimeout(requests.adapters.HTTPAdapter):
         def __init__(self, timeout=None, *args, **kwargs):
@@ -217,8 +217,7 @@ def copy_files(source_location, destination_location, files):
 
     url = _storage_service_url() + 'location/' + destination_location['uuid'] + '/'
     try:
-        timeout = settings.COPY_FILES_TIMEOUT
-        response = _storage_api_session(timeout).post(url, json=move_files)
+        response = _storage_api_session().post(url, json=move_files)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to move files with %s because %s", move_files, e.content)
@@ -266,7 +265,7 @@ def create_file(uuid, origin_location, origin_path, current_location,
 
     LOGGER.info("Creating file with %s", new_file)
     try:
-        session = _storage_api_session(timeout=None)
+        session = _storage_api_session()
         if update:
             new_file['reingest'] = pipeline['uuid']
             url = _storage_service_url() + 'file/' + uuid + '/'

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 # Django Core, alphabetical by import source
+from django.conf import settings as django_settings
 from django.views.generic import View
 
 # External dependencies, alphabetical
@@ -170,7 +171,7 @@ def bulk_extractor(request, fileuuid):
     for report in reports:
         relative_path = os.path.join('logs', 'bulk-' + fileuuid, report + '.txt')
         url = storage_service.extract_file_url(f.transfer_id, relative_path)
-        response = requests.get(url, timeout=120)
+        response = requests.get(url, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
 
         if response.status_code != 200:
             message = 'Unable to retrieve ' + report + ' report for file with UUID ' + fileuuid

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -214,7 +214,7 @@ def get_atom_levels_of_description(clear=True):
 
     # taxonomy 34 is "level of description"
     dest = urljoin(url, 'api/taxonomies/34')
-    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=120)
+    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=django_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     if response.status_code == 200:
         base = 1
         if clear:
@@ -307,7 +307,7 @@ def processing_config_path():
 
 
 def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):
-    stream = requests.get(url, stream=True, timeout=120)
+    stream = requests.get(url, stream=True, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
         content_disposition = stream.headers.get('content-disposition')

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -305,7 +305,7 @@ def ingest_upload_destination_url_check(request):
     url = urljoin(url, request.GET.get('target', ''))
 
     # make request for URL
-    response = requests.request('GET', url, timeout=120)
+    response = requests.request('GET', url, timeout=django_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
 
     # return resulting status code from request
     return HttpResponse(response.status_code)

--- a/src/dashboard/src/installer/steps.py
+++ b/src/dashboard/src/installer/steps.py
@@ -84,7 +84,7 @@ def submit_fpr_agent():
 
     try:
         logger.info("FPR Server URL: {}".format(django_settings.FPR_URL))
-        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=120, verify=True)
+        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=django_settings.FPR_CLIENT_TIMEOUT, verify=True)
         if r.status_code == 201:
             resp['result'] = 'success'
         else:

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -35,7 +35,9 @@ CONFIG_MAPPING = {
     'elasticsearch_timeout': {'section': 'Dashboard', 'option': 'elasticsearch_timeout', 'type': 'float'},
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
-    'copy_files_timeout': {'section': 'Dashboard', 'option': 'copy_files_timeout', 'type': 'int'},
+    'storage_service_client_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'agentarchives_client_timeout': {'section': 'Dashboard', 'option': 'agentarchives_client_timeout', 'type': 'float'},
+    'fpr_client_timeout': {'section': 'Dashboard', 'option': 'fpr_client_timeout', 'type': 'float'},
 
     # [client]
     'db_engine': {'section': 'client', 'option': 'engine', 'type': 'string'},
@@ -56,7 +58,10 @@ elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
-copy_files_timeout = 300
+storage_service_client_timeout = 86400
+agentarchives_client_timeout = 300
+fpr_client_timeout = 60
+
 # django_allowed_hosts = ... Mandatory!
 # django_secret_key = ... Mandatory!
 
@@ -383,6 +388,7 @@ UUID_REGEX = '[\w]{8}(-[\w]{4}){3}-[\w]{12}'
 
 FPR_URL = 'https://fpr.archivematica.org/fpr/api/v2/'
 FPR_VERIFY_CERT = True
+FPR_CLIENT_TIMEOUT = config.get('fpr_client_timeout')
 
 ALLOWED_HOSTS = config.get('allowed_hosts').split(',')
 
@@ -409,10 +415,10 @@ SHARED_DIRECTORY = config.get('shared_directory')
 WATCH_DIRECTORY = config.get('watch_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
+STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 
 ALLOW_USER_EDITS = True
-
-COPY_FILES_TIMEOUT = config.get('copy_files_timeout')
 
 SHIBBOLETH_AUTHENTICATION = config.get('shibboleth_authentication')
 if SHIBBOLETH_AUTHENTICATION:


### PR DESCRIPTION
This is in response to https://jiscdev.atlassian.net/browse/RDSSARK-379.

This pull request ports https://github.com/artefactual/archivematica/pull/747. See the link and the commit description for more details.

New environment strings (incl. defaults):

### Dashboard

```
ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT=86400
ARCHIVEMATICA_DASHBOARD_DASHBOARD_AGENTARCHIVES_TIMEOUT=300
ARCHIVEMATICA_DASHBOARD_DASHBOARD_FPR_CLIENT_TIMEOUT=60
```

`ARCHIVEMATICA_DASHBOARD_DASHBOARD_COPY_FILES_TIMEOUT` is now unused (introduced in #30). Use `ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT` instead.

### MCPClient

```
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_TIMEOUT=86400
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_AGENTARCHIVES_TIMEOUT=300
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_TIMEOUT=86400
```