### PR TITLE
dashboard: make setup_pipeline funcs idempotent

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -114,7 +114,7 @@ def create_pipeline(create_default_locations=False, shared_path=None, api_userna
     return True
 
 
-def _get_pipeline(uuid):
+def get_pipeline(uuid):
     url = _storage_service_url() + 'pipeline/' + uuid + '/'
     try:
         response = _storage_api_session().get(url)
@@ -146,7 +146,7 @@ def get_location(path=None, purpose=None, space=None):
     if space and path:
         path = _storage_relative_from_absolute(path, space['path'])
         space = space['uuid']
-    pipeline = _get_pipeline(get_setting('dashboard_uuid'))
+    pipeline = get_pipeline(get_setting('dashboard_uuid'))
     if pipeline is None:
         return None
     url = _storage_service_url() + 'location/'
@@ -194,7 +194,7 @@ def copy_files(source_location, destination_location, files):
         source_location and destination_location, respectively.  All other
         fields ignored.
     """
-    pipeline = _get_pipeline(get_setting('dashboard_uuid'))
+    pipeline = get_pipeline(get_setting('dashboard_uuid'))
     move_files = {
         'origin_location': source_location['resource_uri'],
         'files': files,
@@ -248,7 +248,7 @@ def create_file(uuid, origin_location, origin_path, current_location,
 
     origin_location and current_location should be URIs for the storage service.
     """
-    pipeline = _get_pipeline(get_setting('dashboard_uuid'))
+    pipeline = get_pipeline(get_setting('dashboard_uuid'))
     if pipeline is None:
         return (None, 'Pipeline not available, see logs.')
     new_file = {

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -434,7 +434,7 @@ def general(request):
 
     dashboard_uuid = helpers.get_setting('dashboard_uuid')
     try:
-        pipeline = storage_service._get_pipeline(dashboard_uuid)
+        pipeline = storage_service.get_pipeline(dashboard_uuid)
     except Exception:
         messages.warning(request, _("Storage server inaccessible. Please contact an administrator or update storage service URL below."))
     else:

--- a/src/dashboard/src/installer/steps.py
+++ b/src/dashboard/src/installer/steps.py
@@ -53,6 +53,10 @@ def set_agent_code(agent_code):
 
 
 def setup_pipeline(org_name, org_identifier):
+    dashboard_uuid = helpers.get_setting('dashboard_uuid')
+    # Setup pipeline only if dashboard_uuid doesn't already exists
+    if dashboard_uuid:
+        return
     # Assign UUID to Dashboard
     dashboard_uuid = str(uuid.uuid4())
     helpers.set_setting('dashboard_uuid', dashboard_uuid)
@@ -106,6 +110,17 @@ def download_fpr_rules():
 
 
 def setup_pipeline_in_ss(use_default_config=False):
+    # Check if pipeline is already registered on SS
+    dashboard_uuid = helpers.get_setting('dashboard_uuid')
+    try:
+        storage_service.get_pipeline(dashboard_uuid)
+    except Exception:
+        logger.warning("SS inaccessible or pipeline not registered.")
+    else:
+        # If pipeline is already registered on SS, then exit
+        logger.warning("This pipeline is already configured on SS.")
+        return
+
     if not use_default_config:
         # Storage service manually set up, just register Pipeline if
         # possible. Do not provide additional information about the shared


### PR DESCRIPTION
When upgrading the qa environments using "make all", a new pipeline is
created on every upgrade and registered on the SS when setup_pipeline
and setup_pipeline_in_ss are invoked in steps.py. This change will make
both methods idempotent, so that:

- if the pipeline already exists no new uuid will be assigned to the
existing pipeline.

- if the pipeline is registered on the SS, no further action will be
needed.

This fixes Jisc issues:
https://github.com/JiscRDSS/rdss-archivematica/issues/134
https://github.com/JiscRDSS/rdss-archivematica/issues/165