### PR TITLE
storageService: add new query timeout

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -40,6 +40,7 @@ CONFIG_MAPPING = {
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
     'storage_service_client_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'storage_service_client_quick_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_quick_timeout', 'type': 'float'},
     'agentarchives_client_timeout': {'section': 'MCPClient', 'option': 'agentarchives_client_timeout', 'type': 'float'},
 
     # [antivirus]
@@ -82,6 +83,7 @@ removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
 clamav_pass_by_reference = False
 storage_service_client_timeout = 86400
+storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 clamav_client_timeout = 600
 clamav_client_backend = clamdscanner    ; Options: clamdscanner or clamscanner
@@ -204,6 +206,7 @@ TEMP_DIRECTORY = config.get('temp_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get('storage_service_client_quick_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 CLAMAV_SERVER = config.get('clamav_server')
 CLAMAV_PASS_BY_REFERENCE = config.get('clamav_pass_by_reference')

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -74,6 +74,10 @@ def _storage_api_session(timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
     return session
 
 
+def _storage_api_quick_session():
+    return _storage_api_session(django_settings.STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT)
+
+
 def _storage_api_params():
     """Return API GET params username=USERNAME&api_key=KEY for use in URL."""
     username = get_setting('storage_service_user', 'test')
@@ -106,7 +110,7 @@ def create_pipeline(create_default_locations=False, shared_path=None, api_userna
     LOGGER.info("Creating pipeline in storage service with %s", pipeline)
     url = _storage_service_url() + 'pipeline/'
     try:
-        response = _storage_api_session().post(url, json=pipeline)
+        response = _storage_api_quick_session().post(url, json=pipeline)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         LOGGER.warning('Unable to create Archivematica pipeline in storage service from %s because %s', pipeline, e, exc_info=True)
@@ -117,7 +121,7 @@ def create_pipeline(create_default_locations=False, shared_path=None, api_userna
 def get_pipeline(uuid):
     url = _storage_service_url() + 'pipeline/' + uuid + '/'
     try:
-        response = _storage_api_session().get(url)
+        response = _storage_api_quick_session().get(url)
         if response.status_code == 404:
             LOGGER.warning("This Archivematica instance is not registered with the storage service or has been disabled.")
         response.raise_for_status()
@@ -158,7 +162,7 @@ def get_location(path=None, purpose=None, space=None):
         'offset': 0,
     }
     while True:
-        response = _storage_api_session().get(url, params=params)
+        response = _storage_api_quick_session().get(url, params=params)
         locations = response.json()
         return_locations += locations['objects']
         if not locations['meta']['next']:
@@ -176,7 +180,7 @@ def browse_location(uuid, path):
     path = base64.b64encode(path)
     url = _storage_service_url() + 'location/' + uuid + '/browse/'
     params = {'path': path}
-    response = _storage_api_session().get(url, params=params)
+    response = _storage_api_quick_session().get(url, params=params)
     browse = response.json()
     browse['entries'] = map(base64.b64decode, browse['entries'])
     browse['directories'] = map(base64.b64decode, browse['directories'])
@@ -399,7 +403,7 @@ def request_file_deletion(uuid, user_id, user_email, reason_for_deletion):
         'user_id': user_id,
     }
     url = _storage_service_url() + 'file/' + uuid + '/delete_aip/'
-    response = _storage_api_session().post(url, json=api_request)
+    response = _storage_api_quick_session().post(url, json=api_request)
     return response.json()
 
 

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -36,6 +36,7 @@ CONFIG_MAPPING = {
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
     'storage_service_client_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'storage_service_client_quick_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_quick_timeout', 'type': 'float'},
     'agentarchives_client_timeout': {'section': 'Dashboard', 'option': 'agentarchives_client_timeout', 'type': 'float'},
     'fpr_client_timeout': {'section': 'Dashboard', 'option': 'fpr_client_timeout', 'type': 'float'},
 
@@ -59,6 +60,7 @@ elasticsearch_timeout = 10
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
 storage_service_client_timeout = 86400
+storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 fpr_client_timeout = 60
 
@@ -416,6 +418,7 @@ WATCH_DIRECTORY = config.get('watch_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get('storage_service_client_quick_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 
 ALLOW_USER_EDITS = True


### PR DESCRIPTION
[RDSSARK-425](https://jiscdev.atlassian.net/browse/RDSSARK-425)

Certain endpoints in SS are expected to return immediately (e.g. `get_pipeline`) but we have a single deadline that applies to all the requests and it's normally set very high (1 day) to deal with some long-running requests that SS can't delay (STORAGE_SERVICE_CLIENT_TIMEOUT=86400).

This pull request only attempts to create a new timeout for those endpoints that are supposed to be fast (e.g. `get_pipeline) so when the SS is unreachable we have a short deadline instead of the recently added deadline meant to be used for long-running operations (which should be delayed anyways but that's being solved separately, i.e. ask Justin about his plans for async ops in SS).

New environments:

- In Dashboard: `ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_QUERY_TIMEOUT=5`
- In MCPClient: `ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_QUERY_TIMEOUT=5`

I couldn't fin da better name. `STORAGE_SERVICE_CLIENT_QUERY_TIMEOUT=5` kind of made sense because we already have `STORAGE_SERVICE_CLIENT_TIMEOUT=86400` for slow requests. I'm open to suggestions.