### PR TITLE
Add checks for empty transfers

### DIFF
--- a/src/MCPClient/lib/clientScripts/verifyTransferCompliance.py
+++ b/src/MCPClient/lib/clientScripts/verifyTransferCompliance.py
@@ -53,11 +53,26 @@ def verifyNothingElseAtTopLevel(SIPDir, ret=0):
     return ret
 
 
+def verifyThereAreFiles(SIPDir, ret=0):
+    """
+    Make sure there are files in the transfer
+    """
+    if not any(
+        files
+        for (_, _, files) in os.walk(SIPDir)
+    ):
+        print("Error, no files found", file=sys.stderr)
+        ret += 1
+
+    return ret
+
+
 if __name__ == '__main__':
     SIPDir = sys.argv[1]
     ret = verifyDirectoriesExist(SIPDir)
     ret = verifyNothingElseAtTopLevel(SIPDir, ret)
     ret = checkDirectory(SIPDir, ret)
+    ret = verifyThereAreFiles(SIPDir, ret)
     if ret != 0:
         import time
         time.sleep(10)


### PR DESCRIPTION
This goes into `verifyTransferCompliance` microservice. Fail the transfer at this stage if there are no files in the transfer.

This seemed to me like the right place to check for files. I experimented with doing so at the approval stage by modifying various bits of MCP Server but there didn't seem to be a suitable point where I could check for files and raise an error in a sensible way. Probably makes more sense here as this happens right after removal of unnecessary files, so if there were only files that are considered unnecessary, there will still be an error.

https://github.com/JiscRDSS/rdss-archivematica/issues/76
https://jiscdev.atlassian.net/browse/RDSSARK-266