### PR TITLE
MCPServer: handle Index AIP error

### DIFF
--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -172,4 +172,9 @@ class jobChainLink:
     @auto_close_db
     def linkProcessingComplete(self, exitCode, passVar=None):
         self.updateExitMessage(exitCode)
-        self.jobChain.nextChainLink(self.getNextChainLinkPK(exitCode), passVar=passVar)
+        next_chain_link_pk = self.getNextChainLinkPK(exitCode)
+        LOGGER.debug('jobChainLink.linkProcessingComplete: nextChainLink(%s)'
+                     ' (exitCode %s, description %s, unit %s)',
+                     next_chain_link_pk, exitCode, self.description,
+                     self.unit.UUID)
+        self.jobChain.nextChainLink(next_chain_link_pk, passVar=passVar)

--- a/src/dashboard/src/components/administration/management/commands/graph_links.py
+++ b/src/dashboard/src/components/administration/management/commands/graph_links.py
@@ -1,0 +1,826 @@
+# -*- coding: utf-8 -*-
+
+r"""Generate a graph of all microservice chainlinks in the database.
+
+Usage example:
+
+$ docker-compose exec --user=root archivematica-dashboard \
+    bash -c "apt-get update && apt-get install --yes graphviz libgraphviz-dev"
+
+$ docker-compose exec --user=root archivematica-dashboard \
+    pip install pygraphviz
+
+$ docker-compose exec archivematica-dashboard \
+    /src/dashboard/src/manage.py graph_links
+"""
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import logging
+import os
+import sys
+import ConfigParser
+
+from django.conf import settings as django_settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+import pygraphviz as pgv
+from lxml import etree
+
+
+linkUUIDtoNodeName = {}
+
+excludedNodes = {
+    '61c316a6-0a50-4f65-8767-1f44b1eeb6dd': 'default fail procedure for transfers. Too many lines',
+    '7d728c39-395f-4892-8193-92f086c0546f': 'default fail procedure for SIPs. Too many lines',
+    '333532b9-b7c2-4478-9415-28a3056d58df': 'reject transfer option.',
+    '19c94543-14cb-4158-986b-1d2b55723cd8': 'reject sip option',
+}
+
+# See http://www.graphviz.org/doc/info/colors.html
+COLORS = {
+    'node_chain_link': 'black',
+    'node_chain_link_start': 'darkgoldenrod',
+    'edge_exit_codes_ok': 'black',
+    'edge_exit_codes_err': 'red',
+    'edge_user_selections': 'green',
+    'edge_watched_directories': 'cyan3',
+    'edge_load_variable': 'orangered',
+    'edge_magic_chain_links': 'brown',
+}
+
+
+# For each MicroServiceChainLink in the MCP Server, the TaskType determines
+# what code will be executed for that task.
+# See: https://wiki.archivematica.org/MCP/TaskTypes
+TASK_TYPES = {
+
+    #
+    # General
+    #
+
+    # description="one instance"
+    'one_instance': '36b2e239-4a57-4aa5-8ebc-7a29139baca6',
+
+    # description="for each file"
+    # 'for_each_file': 'a6b1c323-7d36-428e-846a-e7e819423577',
+
+    #
+    # User choice
+    #
+
+    # description="get user choice to proceed with"
+    # '?': '61fb3874-8ef6-49d3-8a2d-3cb66e86a30c',
+
+    # description="get replacement dic from user choice"
+    # '?': '9c84b047-9a6d-463f-9836-eafa49743b84',
+
+    # description="Get microservice generated list in stdOut"
+    # '?': 'a19bfd9f-9989-4648-9351-013a10b382ed',
+
+    # description="Get user choice from microservice generated list"
+    # '?': '01b748fe-2e9d-44e4-ae5d-113f74c9a0ba',
+
+    #
+    # Unit variables
+    #
+
+    # description="linkTaskManagerSetUnitVariable"
+    'unit_var': '6f0b612c-867f-4dfd-8e43-5b35b7f882d7',
+    # description="linkTaskManagerUnitVariableLinkPull"
+    'unit_var_pull': 'c42184a3-1a7f-4c4d-b380-15d8d97fdd11',
+
+    #
+    # Deprecated
+    #
+
+    # description="goto magic link"
+    # '?': '6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9',
+
+    # description="assign magic link"
+    'assign_magic_link': '3590f73d-5eb0-44a0-91a6-5b2db6655889',
+
+}
+
+
+def query_all_sql(sql, arguments=None):
+    """Ported and simplified from the now-deleted databaseInterface."""
+    with connection.cursor() as c:
+        c.execute(sql, arguments)
+        return c.fetchall()
+
+
+SVGPAN_SCRIPT = etree.CDATA("""
+// https://www.cyberz.org/projects/SVGPan/SVGPan.js
+
+/**
+ *  SVGPan library 1.2.1
+ * ======================
+ *
+ * Given an unique existing element with id "viewport" (or when missing, the first g
+ * element), including the the library into any SVG adds the following capabilities:
+ *
+ *  - Mouse panning
+ *  - Mouse zooming (using the wheel)
+ *  - Object dragging
+ *
+ * You can configure the behaviour of the pan/zoom/drag with the variables
+ * listed in the CONFIGURATION section of this file.
+ *
+ * Known issues:
+ *
+ *  - Zooming (while panning) on Safari has still some issues
+ *
+ * Releases:
+ *
+ * 1.2.1, Mon Jul  4 00:33:18 CEST 2011, Andrea Leofreddi
+ *  - Fixed a regression with mouse wheel (now working on Firefox 5)
+ *  - Working with viewBox attribute (#4)
+ *  - Added "use strict;" and fixed resulting warnings (#5)
+ *  - Added configuration variables, dragging is disabled by default (#3)
+ *
+ * 1.2, Sat Mar 20 08:42:50 GMT 2010, Zeng Xiaohui
+ *  Fixed a bug with browser mouse handler interaction
+ *
+ * 1.1, Wed Feb  3 17:39:33 GMT 2010, Zeng Xiaohui
+ *  Updated the zoom code to support the mouse wheel on Safari/Chrome
+ *
+ * 1.0, Andrea Leofreddi
+ *  First release
+ *
+ * This code is licensed under the following BSD license:
+ *
+ * Copyright 2009-2010 Andrea Leofreddi <a.leofreddi@itcharm.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Andrea Leofreddi ` + "``AS IS''" + ` AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Andrea Leofreddi OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Andrea Leofreddi.
+ */
+
+"use strict";
+
+/// CONFIGURATION
+/// ====>
+
+var enablePan = 1; // 1 or 0: enable or disable panning (default enabled)
+var enableZoom = 1; // 1 or 0: enable or disable zooming (default enabled)
+var enableDrag = 0; // 1 or 0: enable or disable dragging (default disabled)
+
+/// <====
+/// END OF CONFIGURATION
+
+var root = document.documentElement;
+
+var state = 'none', svgRoot, stateTarget, stateOrigin, stateTf;
+
+setupHandlers(root);
+
+/**
+ * Register handlers
+ */
+function setupHandlers(root){
+    setAttributes(root, {
+        "onmouseup" : "handleMouseUp(evt)",
+        "onmousedown" : "handleMouseDown(evt)",
+        "onmousemove" : "handleMouseMove(evt)",
+        //"onmouseout" : "handleMouseUp(evt)", // Decomment this to stop the pan functionality when dragging out of the SVG element
+     });
+
+     if(navigator.userAgent.toLowerCase().indexOf('webkit') >= 0)
+         window.addEventListener('mousewheel', handleMouseWheel, false); // Chrome/Safari
+     else
+         window.addEventListener('DOMMouseScroll', handleMouseWheel, false); // Others
+ }
+
+ /**
+  * Retrieves the root element for SVG manipulation. The element is then cached into the svgRoot global variable.
+  */
+ function getRoot(root) {
+     if(typeof(svgRoot) == "undefined") {
+         var g = null;
+
+         g = root.getElementById("viewport");
+
+         if(g == null)
+             g = root.getElementsByTagName('g')[0];
+
+         if(g == null)
+             alert('Unable to obtain SVG root element');
+
+         setCTM(g, g.getCTM());
+
+         g.removeAttribute("viewBox");
+
+         svgRoot = g;
+     }
+
+     return svgRoot;
+ }
+
+ /**
+  * Instance an SVGPoint object with given event coordinates.
+  */
+ function getEventPoint(evt) {
+     var p = root.createSVGPoint();
+
+     p.x = evt.clientX;
+     p.y = evt.clientY;
+
+     return p;
+ }
+
+ /**
+  * Sets the current transform matrix of an element.
+  */
+ function setCTM(element, matrix) {
+     var s = "matrix(" + matrix.a + "," + matrix.b + "," + matrix.c + "," + matrix.d + "," + matrix.e + "," + matrix.f + ")";
+
+     element.setAttribute("transform", s);
+ }
+
+ /**
+  * Dumps a matrix to a string (useful for debug).
+  */
+ function dumpMatrix(matrix) {
+     var s = "[ " + matrix.a + ", " + matrix.c + ", " + matrix.e + "  " + matrix.b + ", " + matrix.d + ", " + matrix.f + "  0, 0, 1 ]";
+
+     return s;
+ }
+
+ /**
+  * Sets attributes of an element.
+  */
+ function setAttributes(element, attributes){
+     for (var i in attributes)
+         element.setAttributeNS(null, i, attributes[i]);
+ }
+
+ /**
+  * Handle mouse wheel event.
+  */
+ function handleMouseWheel(evt) {
+     if(!enableZoom)
+         return;
+
+     if(evt.preventDefault)
+         evt.preventDefault();
+
+     evt.returnValue = false;
+
+     var svgDoc = evt.target.ownerDocument;
+
+     var delta;
+
+     if(evt.wheelDelta)
+         delta = evt.wheelDelta / 3600; // Chrome/Safari
+     else
+         delta = evt.detail / -90; // Mozilla
+
+     var z = 1 + delta; // Zoom factor: 0.9/1.1
+
+     var g = getRoot(svgDoc);
+
+     var p = getEventPoint(evt);
+
+     p = p.matrixTransform(g.getCTM().inverse());
+
+     // Compute new scale matrix in current mouse position
+     var k = root.createSVGMatrix().translate(p.x, p.y).scale(z).translate(-p.x, -p.y);
+
+         setCTM(g, g.getCTM().multiply(k));
+
+     if(typeof(stateTf) == "undefined")
+         stateTf = g.getCTM().inverse();
+
+     stateTf = stateTf.multiply(k.inverse());
+ }
+
+ /**
+  * Handle mouse move event.
+  */
+ function handleMouseMove(evt) {
+     if(evt.preventDefault)
+         evt.preventDefault();
+
+     evt.returnValue = false;
+
+     var svgDoc = evt.target.ownerDocument;
+
+     var g = getRoot(svgDoc);
+
+     if(state == 'pan' && enablePan) {
+         // Pan mode
+         var p = getEventPoint(evt).matrixTransform(stateTf);
+
+         setCTM(g, stateTf.inverse().translate(p.x - stateOrigin.x, p.y - stateOrigin.y));
+     } else if(state == 'drag' && enableDrag) {
+         // Drag mode
+         var p = getEventPoint(evt).matrixTransform(g.getCTM().inverse());
+
+         setCTM(
+            stateTarget,
+            root.createSVGMatrix().translate(p.x - stateOrigin.x, p.y - stateOrigin.y).multiply(g.getCTM().inverse()).multiply(stateTarget.getCTM())
+         );
+
+         stateOrigin = p;
+     }
+ }
+
+ /**
+  * Handle click event.
+  */
+ function handleMouseDown(evt) {
+     if(evt.preventDefault)
+         evt.preventDefault();
+
+     evt.returnValue = false;
+
+     var svgDoc = evt.target.ownerDocument;
+
+     var g = getRoot(svgDoc);
+
+     if(
+         evt.target.tagName == "svg"
+         || !enableDrag // Pan anyway when drag is disabled and the user clicked on an element
+     ) {
+         // Pan mode
+         state = 'pan';
+
+         stateTf = g.getCTM().inverse();
+
+         stateOrigin = getEventPoint(evt).matrixTransform(stateTf);
+     } else {
+         // Drag mode
+         state = 'drag';
+
+         stateTarget = evt.target;
+
+         stateTf = g.getCTM().inverse();
+
+         stateOrigin = getEventPoint(evt).matrixTransform(stateTf);
+     }
+ }
+
+ /**
+  * Handle mouse button release event.
+  */
+ function handleMouseUp(evt) {
+     if(evt.preventDefault)
+         evt.preventDefault();
+
+     evt.returnValue = false;
+
+     var svgDoc = evt.target.ownerDocument;
+
+     if(state == 'pan' || state == 'drag') {
+         // Quit pan mode
+         state = '';
+     }
+ }
+""")
+
+logging.basicConfig(format='%(message)s', stream=sys.stdout)
+logger = logging.getLogger()
+
+# TODO: the dashboard doens't have access to this file.
+config = ConfigParser.ConfigParser()
+config.read('/etc/archivematica/MCPClient/archivematicaClientModules')
+
+
+def get_script_name(name):
+    """Extract client script name."""
+    if not isinstance(name, basestring):
+        return
+    if config.has_option('supportedCommandsSpecial', name):
+        return config.get('supportedCommandsSpecial', name)
+    if config.has_option('supportedCommands', name):
+        return config.get('supportedCommands', name)
+
+
+def add_edge(g, source_uuid, dest_uuid, color='black', label=None):
+    """Add edges to graph."""
+    if source_uuid in excludedNodes or dest_uuid in excludedNodes:
+        return
+    if source_uuid is None or dest_uuid is None:
+        return
+    if label:
+        g.add_edge(
+            linkUUIDtoNodeName[source_uuid],
+            linkUUIDtoNodeName[dest_uuid],
+            color=color, label=label)
+    else:
+        g.add_edge(
+            linkUUIDtoNodeName[source_uuid],
+            linkUUIDtoNodeName[dest_uuid],
+            color=color)
+
+
+def load_chain_links(g):
+    """Map chain links to nodes in the graph.
+
+    Default links are represented with black arrows.
+    """
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            MicroServiceChainLinks.defaultNextChainLink,
+            TasksConfigs.description,
+            TaskTypes.description,
+            TasksConfigs.taskTypePKReference,
+            MicroServiceChainLinks.microserviceGroup
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON currentTask = TasksConfigs.pk
+        JOIN TaskTypes ON taskType = TaskTypes.pk;
+    """
+    links = query_all_sql(sql)
+    for link in links:
+        pk, defaultNextChainLink, description, taskType, pkRef, group = link
+        if pk in excludedNodes:
+            continue
+        sql = """
+            SELECT
+                execute,
+                arguments
+            FROM StandardTasksConfigs
+            WHERE pk=%s;
+        """
+        script_name = query_all_sql(sql, (pkRef,))
+        arguments = None
+        if script_name:
+            script_name, arguments = script_name[0]
+        elif not script_name:
+            sql = """
+                SELECT
+                    variable,
+                    variableValue,
+                    microServiceChainLink
+                FROM TasksConfigsSetUnitVariable
+                WHERE pk=%s;
+            """
+            returned = query_all_sql(sql, (pkRef,))
+            if returned:
+                script_name = '%s, %s' % (returned[0][0], returned[0][1] or returned[0][2])
+        # Node info:
+        # {MSCL UUID} Name of node
+        # (task type description) taskTypePKReference
+        # [Name of script] Microservice Group
+        node_name = r"{%s} %s\n(%s) %s\n[%s] %s" % (pk, description, taskType, pkRef, script_name or '', group)
+        # Color if start of chain
+        border_color = COLORS['node_chain_link']
+        sql = """
+            SELECT *
+            FROM MicroServiceChains
+            WHERE startingLink=%s;
+        """
+        if query_all_sql(sql, (pk,)):
+            border_color = COLORS['node_chain_link_start']
+        full_script_name = get_script_name(script_name)
+        tooltip = 'Script name: {}. \n'.format(full_script_name) if full_script_name else 'Full script name not found. '
+        tooltip += 'Arguments: {}'.format(arguments) if arguments is not None else 'No arguments'
+        g.add_node(node_name, label=node_name, id=node_name, color=border_color, tooltip=tooltip)
+        linkUUIDtoNodeName[pk] = node_name
+    for link in links:
+        pk = link[0]
+        default_link_id = link[1]
+        if default_link_id is not None:
+            add_edge(g, pk, default_link_id, label='defaultNextChainLink')
+    return
+
+
+def bridge_exit_codes(g):
+    """
+    Connect tasks based on the exit code.
+
+    The edges are red if the exit code is greater than zero and green otherwise.
+    The exit code is included in the label of the edge.
+    """
+    sql = """
+        SELECT
+            microServiceChainLink,
+            nextMicroServiceChainLink,
+            exitCode
+        FROM MicroServiceChainLinksExitCodes;
+    """
+    logger.info('Processing exit codes...')
+    rows = query_all_sql(sql)
+    for row in rows:
+        microServiceChainLink, nextMicroServiceChainLink, exit_code = row
+        if nextMicroServiceChainLink:
+            color = COLORS['edge_exit_codes_ok'] \
+                if not exit_code else COLORS['edge_exit_codes_err']
+            add_edge(g, microServiceChainLink, nextMicroServiceChainLink,
+                     label='EXITCODE={}'.format(exit_code), color=color)
+
+
+def bridge_user_selections(g):
+    """Connect tasks that prompt the user with its corresponding choices.
+
+    The arrows are green and labeled with the choice description.
+    """
+    logger.info('Processing user choices...')
+    sql = """
+        SELECT
+            MicroServiceChainChoice.choiceAvailableAtLink,
+            MicroServiceChains.startingLink,
+            MicroServiceChains.description
+        FROM MicroServiceChainChoice
+        JOIN MicroServiceChains ON (MicroServiceChainChoice.chainAvailable = MicroServiceChains.pk);
+    """
+    rows = query_all_sql(sql)
+    for row in rows:
+        choiceAvailableAtLink, startingLink, description = row
+        if choiceAvailableAtLink and startingLink:
+            add_edge(g, choiceAvailableAtLink, startingLink,
+                     color=COLORS['edge_user_selections'], label=description)
+
+
+def bridge_watched_directories(g):
+    u"""Connect tasks that represent the end of a chain.
+
+    These are the links that move the package to a new watched directory.
+    The arrows are yellow.
+
+    For example:
+
+        > {61a8de9c-7b25-4f0f-b218-ad4dde261eed} Generate DIP
+        > (one instance) ed8c70b7-1456-461c-981b-6b9c84896263
+        > [move_v0.0] Prepare DIP
+
+            [↓] (yellow)
+
+        > {92879a29-45bf-4f0b-ac43-e64474f0f2f9} Upload DIP
+        > (get user choice to proceed with) None
+        > [] Upload DIP
+
+    Not all the chains are triggered by other tasks, e.g. the following task
+    has no successor.
+
+        > {9520386f-bb6d-4fb9-a6b6-5845ef39375f} Approve AIP reingest
+        > (get user choice to proceed with) None
+        > [] Reingest AIP
+
+    """
+    logger.info('Processing watched directories...')
+    sql = """
+        SELECT
+            watchedDirectoryPath,
+            startingLink
+        FROM WatchedDirectories
+        JOIN MicroServiceChains ON (WatchedDirectories.chain = MicroServiceChains.pk);
+    """
+    rows = query_all_sql(sql)
+    for row in rows:
+        watchedDirectoryPath, startingLink = row
+        logger.debug("\nWatched directory [%s] [startingLink=%s]",
+                     watchedDirectoryPath.replace('%watchDirectoryPath%', ''),
+                     startingLink)
+        count = 0
+
+        sql = """
+            SELECT
+                MicroServiceChainLinks.pk,
+                execute,
+                arguments
+            FROM StandardTasksConfigs
+            JOIN TasksConfigs ON (TasksConfigs.taskTypePKReference = StandardTasksConfigs.pk)
+            JOIN MicroServiceChainLinks ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+            WHERE
+                execute LIKE 'move%%'
+                AND taskType = %s
+                AND (arguments LIKE %s OR arguments LIKE %s);
+        """
+        rows2 = query_all_sql(sql, (
+            TASK_TYPES['one_instance'],
+            '%{}%'.format(watchedDirectoryPath.replace('%', '\%')),
+            '%{}%'.format(watchedDirectoryPath.replace('%watchDirectoryPath%', '%sharedPath%watchedDirectories/', 1).replace('%', '\%')),
+        ))
+        for row2 in rows2:
+            microServiceChainLink, execute, arguments = row2
+            add_edge(g, microServiceChainLink, startingLink,
+                     color=COLORS['edge_watched_directories'],
+                     label=watchedDirectoryPath)
+            logger.debug('  MATCHED SOURCE:\n   -> %s \n   -> %s\n   -> %s', microServiceChainLink, execute, arguments)
+            count += 1
+
+        if count == 0:
+            logger.info("No sources for watched directory: %s", watchedDirectoryPath)
+
+
+def bridge_magic_chain_links(g):
+    """Bridge magic chain links."""
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            TasksConfigsAssignMagicLink.execute
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        JOIN TasksConfigsAssignMagicLink ON (TasksConfigsAssignMagicLink.pk = TasksConfigs.taskTypePKReference)
+        WHERE TasksConfigs.taskType = %s;
+    """
+    rows = query_all_sql(sql, (TASK_TYPES['assign_magic_link'],))
+    for row in rows:
+        microServiceChainLink, magicLink = row
+        node = g.get_node(linkUUIDtoNodeName[microServiceChainLink])
+        # Keep a list of visited nodes to avoid infinite recursion
+        visited_nodes = {node: None}
+        count = bridge_nagic_chain_links_recursive_assist(g, node, magicLink,
+                                                          visited_nodes)
+        if count == 0:
+            logger.info("No loads of set link: %s", node)
+
+
+def bridge_nagic_chain_links_recursive_assist(g, node, magic_link,
+                                              visited_nodes):
+    """Bridge magic chain links."""
+    ret = 0
+    link = node[1:node.find('}')]
+    sql = """
+        SELECT MicroServiceChainLinks.pk
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        WHERE
+            TasksConfigs.taskType = %s
+            AND MicroServiceChainLinks.pk = %s;
+    """
+    rows = query_all_sql(sql, (
+        TASK_TYPES['assign_magic_link'],
+        link,
+    ))
+    # if it's loading it, set the load and return
+    if len(rows):
+        add_edge(g, link, magic_link, color=COLORS['edge_magic_chain_links'])
+        return 1
+    else:
+        for neigh in g.neighbors_iter(node):
+            if neigh in visited_nodes:
+                continue
+            visited_nodes[neigh] = None
+            ret += bridge_nagic_chain_links_recursive_assist(g, neigh,
+                                                             magic_link,
+                                                             visited_nodes)
+    return ret
+
+
+def bridge_load_variable(g):
+    """Bridge load variable links."""
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            TasksConfigsUnitVariableLinkPull.variable,
+            TasksConfigsUnitVariableLinkPull.defaultMicroServiceChainLink
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        JOIN TasksConfigsUnitVariableLinkPull ON (TasksConfigsUnitVariableLinkPull.pk = TasksConfigs.taskTypePKReference)
+        WHERE TasksConfigs.taskType = %s;
+    """
+    rows = query_all_sql(sql, (TASK_TYPES['unit_var_pull'],))
+    for row in rows:
+        count = 0
+        microServiceChainLink, variable, defaultMicroServiceChainLink = row
+        sql = """
+            SELECT
+                MicroServiceChainLinks.pk,
+                TasksConfigsSetUnitVariable.variable,
+                TasksConfigsSetUnitVariable.microServiceChainLink
+            FROM MicroServiceChainLinks
+            JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk
+            JOIN TasksConfigsSetUnitVariable ON TasksConfigsSetUnitVariable.pk = TasksConfigs.taskTypePKReference
+            WHERE
+                TasksConfigs.taskType = %s
+                AND TasksConfigsSetUnitVariable.variable = %s;
+        """
+        rows2 = query_all_sql(sql, (
+            TASK_TYPES['unit_var'],
+            variable,
+        ))
+        for row2 in rows2:
+            microServiceChainLink2, variable, microServiceChainLinkDest = row2
+            add_edge(g, microServiceChainLink, microServiceChainLinkDest,
+                     color=COLORS['edge_load_variable'], label=variable)
+            count += 1
+        if defaultMicroServiceChainLink:
+            add_edge(g, microServiceChainLink, defaultMicroServiceChainLink,
+                     color=COLORS['edge_load_variable'], label='default MSCL')
+        if count == 0:
+            logger.info("No bridge variable set for %s",
+                        linkUUIDtoNodeName[microServiceChainLink])
+
+
+def add_svgpan(filename):
+    """
+    Change the SVG document to allow zooming and panning.
+
+    This is useful when viewing the graph from a browser.
+    Embed the JavaScript snippet stored in SVGPAN_SCRIPT.
+    """
+    xml = etree.parse(filename)
+    svg = xml.getroot()
+    svg.set('width', '100%')
+    svg.set('height', '100%')
+    del svg.attrib['viewBox']
+    g = svg.find('{http://www.w3.org/2000/svg}g')
+    g.set('id', 'viewport')
+    g.set('transform', 'matrix(0.13429683446884155,0,0,0.13429683446884155,-878.8951971178758,2349.1367317996337)')
+    script = etree.Element('script')
+    script.set('type', 'text/ecmascript')
+    script.text = SVGPAN_SCRIPT
+    g.addprevious(script)
+    g.find('{http://www.w3.org/2000/svg}title').text = 'Archivematica MCP Workflows'
+    xml.write(filename)
+
+
+def main(format, verbosity):
+    """Entry point."""
+    if verbosity > 1:
+        logger.setLevel(logging.DEBUG)
+    g = pgv.AGraph(strict=True, directed=True)
+
+    # Nodes
+    load_chain_links(g)
+
+    # Edges
+    bridge_exit_codes(g)
+    bridge_user_selections(g)
+    bridge_watched_directories(g)
+    bridge_load_variable(g)
+    bridge_magic_chain_links(g)
+
+    # HACK? Represent the connection of the transfer and the ingest chains.
+    #
+    #     > {3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5} Move to SIP creation directory for completed transfers
+    #     > (one instance) ac562701-7672-4e1d-a318-b986b7c9007c
+    #     > [moveTransfer_v0.0] Create SIP from Transfer
+    #
+    #         [↓] (black)
+    #
+    #     > {70669a5b-01e4-4ea0-ac70-10292f87da05} Set file permissions
+    #     > (one instance) 6157fe87-26ff-49da-9899-d9036b21c4b0
+    #     > [setDirectoryPermissionsForAppraisal_v0.0] Verify SIP compliance
+    #
+    add_edge(g, '3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5', '70669a5b-01e4-4ea0-ac70-10292f87da05', label='Transfer -> Ingest (manual)')
+
+    g.layout(prog='dot')
+
+    date = datetime.date.today()
+    filename = os.path.join(django_settings.SHARED_DIRECTORY, 'tmp/chainlinks-{}.{}'.format(date, format))
+    draw_args = "-Goverlap=prism "
+    if verbosity > 1:
+        draw_args += "-v "
+
+    ret = 1
+    try:
+        print(filename)
+        g.draw(filename, args=draw_args)
+        ret = 0
+    except:
+        logger.exception('g.draw() failed! See exception details below...\n\n')
+
+    if ret == 0 and format == 'svg':
+        add_svgpan(filename)
+
+    return ret
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('-f', '--format', choices=['png', 'svg'], default='svg')
+
+    def handle(self, *args, **options):
+        main(options['format'], options['verbosity'])

--- a/src/dashboard/src/components/administration/management/commands/json_links.py
+++ b/src/dashboard/src/components/administration/management/commands/json_links.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+
+"""Management command that dumps the workflow contents as JSON."""
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+import ast
+import io
+import logging
+import json
+import os
+import tempfile
+import sys
+
+import django
+from django.conf import settings as django_settings
+from django.core.management.base import BaseCommand
+
+# Workflow models
+from main.models import WatchedDirectory
+from main.models import MicroServiceChain
+from main.models import MicroServiceChainLink
+from main.models import MicroServiceChainChoice
+from main.models import MicroServiceChainLinkExitCode
+from main.models import MicroServiceChoiceReplacementDic
+from main.models import StandardTaskConfig
+from main.models import TaskConfigAssignMagicLink
+from main.models import TaskConfigUnitVariableLinkPull
+from main.models import TaskConfigSetUnitVariable
+
+# Processing models
+from main.models import Job
+
+
+# This dict was extracted from the TaskTypes table, attributes: model, deprecated, description
+# More info here: https://wiki.archivematica.org/MCP/TaskTypes
+TASK_TYPES = {
+    '01b748fe-2e9d-44e4-ae5d-113f74c9a0ba': (StandardTaskConfig, 'Get user choice from microservice generated list', 'linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList'),
+    '36b2e239-4a57-4aa5-8ebc-7a29139baca6': (StandardTaskConfig, 'One instance', 'linkTaskManagerDirectories'),
+    'a19bfd9f-9989-4648-9351-013a10b382ed': (StandardTaskConfig, 'Get microservice generated list in stdout', 'linkTaskManagerGetMicroserviceGeneratedListInStdOut'),
+    'a6b1c323-7d36-428e-846a-e7e819423577': (StandardTaskConfig, 'For each file', 'linkTaskManagerFiles'),
+    '61fb3874-8ef6-49d3-8a2d-3cb66e86a30c': (MicroServiceChainChoice, 'Get user choice to proceed with', 'linkTaskManagerChoice'),
+    '9c84b047-9a6d-463f-9836-eafa49743b84': (MicroServiceChoiceReplacementDic, 'Get replacement dic from user choice', 'linkTaskManagerReplacementDicFromChoice'),
+    '6f0b612c-867f-4dfd-8e43-5b35b7f882d7': (TaskConfigSetUnitVariable, 'linkTaskManagerSetUnitVariable', 'linkTaskManagerSetUnitVariable'),
+    'c42184a3-1a7f-4c4d-b380-15d8d97fdd11': (TaskConfigUnitVariableLinkPull, 'linkTaskManagerUnitVariableLinkPull', 'linkTaskManagerUnitVariableLinkPull'),
+
+    # D E P R E C A T E D
+    '3590f73d-5eb0-44a0-91a6-5b2db6655889': (TaskConfigAssignMagicLink, 'Assign magic link', 'linkTaskManagerAssignMagicLink'),
+    '6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9': (None, 'Goto magic link', 'linkTaskManagerLoadMagicLink'),
+}
+
+
+def process_chain_link_task_details(link_dict, link, task_config):
+    try:
+        ttype = TASK_TYPES[task_config.tasktype_id]
+    except KeyError:
+        # I could just make this an error but it's pretty bad
+        raise ValueError('Unknown task type: %s', task_config.tasktype_id)
+    else:
+        model, description, manager_class_name = ttype
+
+    link_config = {
+        '@model': model.__name__ if model is not None else None,
+        '@manager': manager_class_name
+    }
+    link_dict['config'] = link_config
+
+    if model == StandardTaskConfig:
+        try:
+            stdtask_config = StandardTaskConfig.objects.get(id=task_config.tasktypepkreference)
+        except StandardTaskConfig.DoesNotExist:
+            logging.error('Link %s points to a StandardTaskConfig tuple that is missing!', link.id)
+        else:
+            link_config['execute'] = stdtask_config.execute
+            link_config['arguments'] = stdtask_config.arguments
+            link_config['filter_subdir'] = stdtask_config.filter_subdir
+            link_config['filter_file_start'] = stdtask_config.filter_file_start
+            link_config['filter_file_end'] = stdtask_config.filter_file_end
+            link_config['stdout_file'] = stdtask_config.stdout_file
+            link_config['stderr_file'] = stdtask_config.stderr_file
+            link_config['requires_output_lock'] = stdtask_config.requires_output_lock
+
+    elif model == MicroServiceChainChoice:
+        choices = MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=link.id)
+        link_config['chain_choices'] = list(item.chainavailable_id for item in choices)
+        if not choices.count():
+            logging.error('Link %s has zero MicroServiceChoiceReplacementDic tuples', link.id)
+
+    elif model == TaskConfigSetUnitVariable:
+        try:
+            config = TaskConfigSetUnitVariable.objects.get(id=task_config.tasktypepkreference)
+        except TaskConfigSetUnitVariable.DoesNotExist:
+            logging.error('Link %s points to a TaskConfigSetUnitVariable tuple that is missing!', link.id)
+        else:
+            link_config['variable'] = config.variable
+            link_config['variable_value'] = config.variablevalue
+            link_config['chain_id'] = config.microservicechainlink_id
+
+    elif model == MicroServiceChoiceReplacementDic:
+        dicts = MicroServiceChoiceReplacementDic.objects.filter(choiceavailableatlink_id=link.id)
+        link_config['replacements'] = list()
+        if not dicts.count():
+            logging.error('Link %s has zero MicroServiceChoiceReplacementDic tuples', link.id)
+        for item in dicts:
+            rep = {}
+            link_config['replacements'].append(rep)
+            rep['id'] = item.id
+            rep['description'] = i18nize_field(item.description, description='Link choice (replacement dict)')
+            try:
+                rep['items'] = {key.strip('%'): value for key, value in ast.literal_eval(item.replacementdic).items()}
+            except (SyntaxError, ValueError):
+                logging.error('Link %s points to a MicroServiceChoiceReplacementDic with syntax issues', link.id)
+
+    elif model == TaskConfigUnitVariableLinkPull:
+        try:
+            unit_var = TaskConfigUnitVariableLinkPull.objects.get(id=task_config.tasktypepkreference)
+        except TaskConfigUnitVariableLinkPull.DoesNotExist:
+            logging.error('Link %s points to a TaskConfigUnitVariableLinkPull that is missing', link.id)
+        else:
+            link_config['variable'] = unit_var.variable
+            link_config['chain_id'] = unit_var.defaultmicroservicechainlink_id
+
+    elif model == TaskConfigAssignMagicLink:
+        try:
+            config = TaskConfigAssignMagicLink.objects.get(id=task_config.tasktypepkreference)
+        except TaskConfigAssignMagicLink.ObjectDoesNotExist:
+            logging.error('Link %s points to a TaskConfigAssignMagicLink that is missing', link.id)
+        else:
+            link_config['link_id'] = config.execute_id
+
+    elif model is None and manager_class_name == 'linkTaskManagerLoadMagicLink':
+        pass
+
+    else:
+        raise ValueError('Unexpected link configuration type (type_id={})'.format(task_config.tasktype_id))
+
+
+def job_status_unicode(value):
+    status = dict(Job.STATUS)
+    try:
+        return unicode(status[int(value)])
+    except ValueError:
+        # https://github.com/artefactual/archivematica/issues/784
+        d = {
+            'Failed': 4,
+            'Completed successfully': 2,
+        }
+        if value in d:
+            return unicode(status[d[value]])
+        raise
+    except KeyError:
+        logging.error('Job status %s cannot be recognized', value)
+        return job_status_unicode(Job.STATUS_UNKNOWN)
+
+
+def link_exit_codes(link_id):
+    exit_codes = MicroServiceChainLinkExitCode.objects.filter(microservicechainlink_id=link_id)
+    ret = {}
+    for item in exit_codes:
+        props = {}
+        ret[int(item.exitcode)] = props
+        props['job_status'] = job_status_unicode(item.exitmessage)
+        if item.nextmicroservicechainlink_id is None:
+            logging.warning('Link %s with exit code %s has no next link assigned', link_id, item.exitcode)
+        props['link_id'] = item.nextmicroservicechainlink_id
+    return ret
+
+
+def i18nize_field(field, description):
+    """
+    Return a i18n dictionary with the existing translations.
+    Side effect: update global catalogue.
+    """
+    value = unicode(field)
+    if not hasattr(sys.modules[__name__], 'i18n_catalogues'):
+        return dict(en=value)
+    catalogues = getattr(sys.modules[__name__], 'i18n_catalogues')
+
+    # Update English with the source message
+    catalogues['en'][value] = dict(message=value, description=description)
+
+    # Build translation object
+    translations = dict()
+    for lang, messages in catalogues.items():
+        if field in messages:
+            translations[lang] = messages[field]['message']
+    return translations
+
+
+def i18n_load_locales(path, catalogues):
+    for item in os.listdir(path):
+        if not item.endswith('.json'):
+            continue
+        lang = item[:len(item) - len('.json')]
+        with open(os.path.join(path, item), 'r') as fh:
+            catalogues[lang] = json.load(fh)
+
+
+def i18n_write_locale_json(path, catalogue):
+    try:
+        with io.open(path, 'w', encoding='utf-8') as fh:
+            logging.info("Writing i18n JSON: %s", path)
+            blob = json.dumps(catalogue, ensure_ascii=False, sort_keys=True, separators=(',', ': '), indent=4)
+            fh.write(blob)
+    except IOError:
+        logging.exception('Error writing to %s', path)
+        return 1
+
+
+def main(locale_dir=None):
+    # export is going to be our container to dump the three main types we need
+    # to export: watched directories, chains and links. We realize these types
+    # may not be ideal to describe a workflow but it is the way we originally
+    # did in Archivematica. Watched directories are responsible for starting
+    # new chains of processing when new directories or files are added to it.
+    # Chains are basically entry points to a series of links.
+    export = dict(watched_directories=list(), chains=dict(), links=dict())
+
+    if locale_dir:
+        locale_dir = os.path.abspath(locale_dir)
+        catalogues = dict(en={})
+        i18n_load_locales(locale_dir, catalogues)
+        setattr(sys.modules[__name__], 'i18n_catalogues', catalogues)
+
+    #
+    # Watched directories
+    #
+    for item in WatchedDirectory.objects.all():
+        logging.info('Adding watched directory: %s', item.watched_directory_path)
+        wd = {
+            'path': item.watched_directory_path.replace('%watchDirectoryPath%', '/'),
+            'unit_type': item.expected_type.description,
+            'chain_id': item.chain.pk,
+            'only_dirs': item.only_act_on_directories
+        }
+        export['watched_directories'].append(wd)
+
+    #
+    # Chains
+    #
+    for item in MicroServiceChain.objects.all():
+        logging.info('Adding chain: %s', item.description)
+        msc = {
+            'description': i18nize_field(item.description, description='Chain description'),
+            'link_id': item.startinglink_id,
+        }
+        export['chains'][item.id] = msc
+
+    #
+    # Tasks
+    #
+    for item in MicroServiceChainLink.objects.all():
+        logging.info('Adding link: %s', item.id)
+
+        link = {}
+        export['links'][item.id] = link
+        link['group'] = i18nize_field(item.microservicegroup, description='Link group')
+        link['fallback_job_status'] = job_status_unicode(item.defaultexitmessage)
+        link['fallback_link_id'] = item.defaultnextchainlink_id
+
+        # Exit codes
+        link['exit_codes'] = link_exit_codes(item.id)
+        if not len(link['exit_codes']):
+            logging.warning('Link %s has no connections with exit codes', item.id)
+
+        # Link configuration details (TaskConfig stuff)
+        try:
+            task_config = item.currenttask
+        except django.core.exceptions.ObjectDoesNotExist:
+            logging.error('Found orphan task (MicroServiceChainLink.pk=%s), currenttask foreign key cannot be found', item.id)
+        else:
+            link['description'] = i18nize_field(task_config.description, description='Link description')
+            process_chain_link_task_details(link, item, task_config)
+
+    #
+    # Save output
+    #
+
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="json-links-",
+                                dir=os.path.join(django_settings.SHARED_DIRECTORY, 'tmp'))
+    with open(path, 'w') as fd:
+        json.dump(export, fd, ensure_ascii=False, sort_keys=True, separators=(',', ': '), indent=4)
+        print(path)
+
+    if locale_dir:
+        # Update en.json with new messages
+        i18n_write_locale_json(os.path.abspath(os.path.join(locale_dir, 'en.json')), catalogues['en'])
+
+    return 0
+
+
+def setup_logging(verbosity):
+    """
+    archivematica-devtools imposes the logging settings used in the dashboard.
+    That may be convenient in some cases but in this particular script I need
+    logging events to be sent to stderr instead.
+    """
+    # Undo Archivematica's logging settings
+    root = logging.getLogger()
+    map(root.removeHandler, root.handlers[:])
+    map(root.removeFilter, root.filters[:])
+
+    # Set level
+    root.setLevel(logging.DEBUG if verbosity > 1 else logging.WARNING if verbosity == 1 else logging.ERROR)
+
+    # Set up local logger
+    logging.basicConfig(stream=sys.stderr, format='[%(asctime)s] [%(levelname)8s] - %(message)s (%(filename)s:%(lineno)s)')
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        main()

--- a/src/dashboard/src/main/migrations/0051_index_aip_error.py
+++ b/src/dashboard/src/main/migrations/0051_index_aip_error.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration_up(apps, schema_editor):
+    """Workflow migration making Index AIP continue even when it fails.
+
+    Before this change, Index AIP used to fall back to "Email fail report"
+    which interrupted the process.
+    """
+
+    MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
+
+    clean_up_after_storing_aip_pk = 'b7cf0d9a-504f-4f4e-9930-befa817d67ff'
+    MicroServiceChainLink.objects.filter(
+        pk='48703fad-dc44-4c8e-8f47-933df3ef6179'
+    ).update(
+        defaultnextchainlink_id=clean_up_after_storing_aip_pk,
+    )
+
+
+def data_migration_down(apps, schema_editor):
+    """Unapply migration."""
+
+    MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
+
+    email_fail_report_pk = '7d728c39-395f-4892-8193-92f086c0546f'
+    MicroServiceChainLink.objects.filter(
+        pk='48703fad-dc44-4c8e-8f47-933df3ef6179'
+    ).update(
+        defaultnextchainlink_id=email_fail_report_pk,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0050_fix_upload_qubit_setting'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            data_migration_up,
+            data_migration_down),
+    ]


### PR DESCRIPTION
This fixes https://jiscdev.atlassian.net/browse/RDSSARK-418.

Add a new migration that changes the way that errors in `Index AIP` are handled.

After an error we used to default to `7d728c39`, which interrupts the processing as shown below:

```
      Email fail report
      7d728c39-395f-4892-8193-92f086c0546f
        \
          Cleanup failed SIP
          b2ef06b9-bca4-49da-bc5c-866d7b3c4bb1
            \
              Move to the failed directory
              828528c2-2eb9-4514-b5ca-dfd1f7cb5b8c
```

Now we continue with `b7cf0d9a` instead like when it succeeds:

```
{
    "config": {
        "@manager": "linkTaskManagerDirectories",
        "@model": "StandardTaskConfig",
        "arguments": "\"%SIPUUID%\"",
        "execute": "postStoreAIPHook_v1.0",
        "filter_file_end": null,
        "filter_file_start": null,
        "filter_subdir": null,
        "requires_output_lock": false,
        "stderr_file": null,
        "stdout_file": null
    },
    "description": {
        "en": "Clean up after storing AIP"
    },
    "exit_codes": {
        "0": {
            "job_status": "Completed successfully",
            "link_id": "d5a2ef60-a757-483c-a71a-ccbffe6b80da"
        }
    },
    "fallback_job_status": "Failed",
    "fallback_link_id": "d5a2ef60-a757-483c-a71a-ccbffe6b80da",
    "group": {
        "en": "Store AIP"
    }
}
```

This pull request also ports `json_links` and `graph_links` from the devtools repo. This enables the developer to reason about the workflow when changes need to be made. `graph_links` include some instructions on how should be used.