### PR TITLE
MCPClient: Send an email after aip's are stored

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -120,6 +120,7 @@ use_tls = True
 file_path =
 amazon_ses_region = us-east-1
 default_from_email = webmaster@example.com
+test_email=webmaster@example.com
 subject_prefix = [Archivematica]
 timeout = 300
 #server_email =

--- a/src/archivematicaCommon/lib/email_settings.py
+++ b/src/archivematicaCommon/lib/email_settings.py
@@ -32,6 +32,7 @@ CONFIG_MAPPING = {
     'email_file_path': {'section': 'email', 'option': 'file_path', 'type': 'string'},
     'email_amazon_ses_region': {'section': 'email', 'option': 'amazon_ses_region', 'type': 'string'},
     'default_from_email': {'section': 'email', 'option': 'default_from_email', 'type': 'string'},
+    'test_email': {'section': 'email', 'option': 'test_email', 'type': 'string'},
     'email_subject_prefix': {'section': 'email', 'option': 'subject_prefix', 'type': 'string'},
     'email_timeout': {'section': 'email', 'option': 'timeout', 'type': 'int'},
     'server_email': {'section': 'email', 'option': 'server_email', 'type': 'int'},
@@ -70,6 +71,7 @@ def get_settings(config):
 
         # General settings, not backend-specific
         DEFAULT_FROM_EMAIL=config.get('default_from_email'),
+        TEST_EMAIL=config.get('test_email'),
         EMAIL_SUBJECT_PREFIX=config.get('email_subject_prefix'),
         EMAIL_TIMEOUT=config.get('email_timeout', None),
     )


### PR DESCRIPTION
Working on https://jiscdev.atlassian.net/browse/RDSSARK-103

This is a work-in-progress for a temporary fix to notifying users of job state.
In the long run notifications should be sent on the JISC message queue.

This adds functionality to the post-store-aip-hook to send emails to all registered users.
It also removes the ability to store to dspace as this is not needed for RDSS.

Test users to send email to can be added to configuration. Some advice is needed here on how this can come from environment variables.
