### PR TITLE
Dashboard: Add a new API to retrieve job metrics

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -42,4 +42,5 @@ urlpatterns = [
     url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom, name='fetch_atom_lods'),
     url(r'filesystem/metadata/$', views.path_metadata),
     url(r'processing-configuration/(?P<name>\w{1,16})', views.processing_configuration),
+    url(r'reporting/packages/(?P<unit_uuid>' + settings.UUID_REGEX + ')', views.package_reporting),
 ]

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -25,7 +25,7 @@ import uuid
 import re
 
 # Core Django, alphabetical
-from django.db.models import Q
+from django.db.models import Q, Sum
 import django.http
 from django.conf import settings as django_settings
 
@@ -705,3 +705,45 @@ def processing_configuration(request, name):
         return django.http.HttpResponse(content, content_type='text/xml')
     except IOError:
         raise django.http.Http404
+
+
+@_api_endpoint(expected_methods=['GET'])
+def package_reporting(request, unit_uuid):
+
+    """
+    API to provide a set of metrics about the status of a given job in JSON format.
+    The request parameter is a UUID which can be the SIP UUID or the transfer UUID.
+    The response gives details about the job and all its tasks.
+    """
+    
+    num_files = models.File.objects.filter(Q(sip_id=unit_uuid) | Q(transfer_id=unit_uuid)).count()
+    total_size = models.File.objects.filter(Q(sip_id=unit_uuid) | Q(transfer_id=unit_uuid)).aggregate(Sum('size'))
+    
+    job = models.Job.objects.filter(sipuuid=unit_uuid).first()
+    if not job:
+        response = {'error': True, 'message': 'cannot find "uuid".'}
+        return helpers.json_response(response, status_code=404)
+    
+    tasks = job.task_set.all()
+    
+    response = {}
+    duration = 0
+    task_vals = []
+    
+    for task in tasks:
+        task_vals.append({
+                'task': task.client,
+                'CPU time': int((task.endtime - task.starttime).total_seconds())
+        })
+        duration = duration + (task.endtime - task.starttime).total_seconds()
+    
+    response['job'] = {
+        'phase': job.unittype,
+        'microservice_group': job.microservicegroup,
+        'tasks': tasks.count(),
+        'duration': int(duration),
+        'number_of_files': num_files,
+        'files_size': total_size,
+    }
+    response['tasks'] = task_vals
+    return helpers.json_response(response)


### PR DESCRIPTION
Working on https://jiscdev.atlassian.net/browse/RDSSARK-420

This is work-in-progress.

Adds the API URL reporting/packages/{UUID} to provide metrics about jobs
and their tasks.

Design has been taken from https://jiscdev.atlassian.net/wiki/x/AYB7EQ.

This needs reviewing for correct use of django models and completeness of the response.