### PR TITLE
Send an email when a workflow has succeeded or failed

### DIFF
--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -34,6 +34,8 @@ from main.models import Job, Report
 from custom_handlers import get_script_logger
 from externals.HTML import HTML
 
+import emailOnCompletion
+
 
 django.setup()
 
@@ -208,3 +210,5 @@ if __name__ == '__main__':
     # Generate report in plain text and store it in the database
     content = get_content_for(args.unit_type, args.unit_name, args.unit_uuid, html=False)
     store_report(content, args.unit_type, args.unit_name, args.unit_uuid)
+
+    emailOnCompletion.run_job(args.unit_uuid, False)

--- a/src/MCPClient/lib/clientScripts/emailOnCompletion.py
+++ b/src/MCPClient/lib/clientScripts/emailOnCompletion.py
@@ -1,0 +1,127 @@
+
+import argparse
+import sys
+
+import django
+from django.conf import settings as mcpclient_settings
+from django.contrib.auth.models import User
+from django.core.mail.message import EmailMessage
+from django.utils.translation import ugettext as _
+
+from contrib import utils
+
+from custom_handlers import get_script_logger
+from main import models
+from email.mime.text import MIMEText
+
+django.setup()
+
+logger = get_script_logger('archivematica.mcp.client.emailOnCompletion')
+
+FAILED_JOB_STEP = 4
+MAX_ATTACHMENT_SIZE = 100000  # Bytes. Attachment can have messages from every file so limit this.
+GENERAL_FAILURE = _('Internal Processing Error. Contact your administrator for help.')
+
+
+def get_recipients():
+    """ Gets the active users to send emails to. If the setting TEST_EMAIL is defined, the email will
+    be sent to that user.
+    TODO For Jisc, we want to send to administrative users only.
+    """
+    email_to = getattr(mcpclient_settings, 'TEST_EMAIL', '')
+    if not email_to:
+        return User.objects.filter(is_active=True).values_list('email', flat=True).exclude(email__in=['demo@example.com', ''])
+    else:
+        return [email_to]
+
+
+def send_email(subject, to, content, attachmentText):
+    """ Send the email with the given parameters. If attachmentText is empty no attachment
+    will be sent
+    """
+    try:
+        logger.info('Sending workflow completion email')
+        mail = EmailMessage(subject, content, mcpclient_settings.DEFAULT_FROM_EMAIL, to)
+        if attachmentText:
+            attachment = MIMEText(attachmentText)
+            attachment.add_header('Content-Disposition', 'attachment; filename=TaskDetails.txt')
+            mail.attach(attachment)
+
+        return mail.send()
+    except:
+        logger.exception('Report email was not delivered')
+        raise
+    else:
+        logger.info('Report sent successfully!')
+
+
+def get_workflow_details(unit_uuid):
+    """ Get basic details about the ended workflow with the given uuid for sending in an email.
+    If there any any jobs that have failed, get a general message about the failure.
+    Task details from each failed job are added as an attachment.
+    """
+    jobs = models.Job.objects.filter(sipuuid=unit_uuid).order_by('-createdtime')
+    if not jobs:
+        raise ValueError('There are no job with the given SIP of Transfer UUID %s', unit_uuid)
+
+    email_content = "Completion report for job with directory {0}\n\n".format(utils.get_directory_name_from_job(jobs))
+
+    job_details = ""
+    task_details = ""
+    whole_flow_success = True
+    for job in jobs:
+        if job.currentstep == models.Job.STATUS_FAILED:
+            job_details += _('Job failed: (%s)\n') % job.jobtype
+            messages = job.microservicechainlink.jobfailmessage_set.all()
+            job_details += '        {0}\n'.format(messages[0].message if messages.exists() else GENERAL_FAILURE)
+
+            # TODO This check is done in the UI but looks unreliable to me. Is it better to
+            # check the microservicechainlink ID, or some other measure of failure?
+            if (job.microservicechainlink.microservicegroup == 'Failed SIP' or
+                    job.microservicechainlink.microservicegroup == 'Failed transfer'):
+                whole_flow_success = False
+
+            for task in job.task_set.all():
+                if len(task_details) < MAX_ATTACHMENT_SIZE and task.stderror.strip():
+                    task_details += 'Task {0}: {1}'.format(task.execution, task.stderror)
+
+    email_content += _("The preservation workflow %s.\n\n") % ("succeeded" if whole_flow_success else "failed")
+    if whole_flow_success:
+        email_content += _("The jobs below failed but did not cause the preservation to fail.\n\n")
+    else:
+        email_content += _("The problems below caused the preservation to fail.\n\n")
+
+    email_content += job_details
+
+    attachment = ""
+    if task_details:
+        attachment = _("Detailed Messages\n\n") + task_details
+
+    return email_content, attachment
+
+
+def run_job(unit_uuid, stdout):
+    to = get_recipients()
+    if not to:
+        logger.error('Nobody to send it to. Please add users with valid email addresses in the dashboard.')
+        return 1
+
+    subject = _('Archivematica Completion Report for %s') % (unit_uuid)
+
+    # Generate email message and send it.
+    content, attachment = get_workflow_details(unit_uuid)
+    send_email(subject, to, content, attachment)
+
+    if stdout:
+        print(content)
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--unitIdentifier', action='store', dest='unit_uuid', required=True)
+    parser.add_argument('-f', '--from', action='store', dest='from', default='ArchivematicaSystem@archivematica.org')
+    parser.add_argument('--stdout', action='store_true', dest='stdout', default=False)
+    args = parser.parse_args()
+
+    sys.exit(run_job(args.unit_uuid, args.stdout))

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -15,6 +15,7 @@ from main import models
 # archivematicaCommon
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
+import emailOnCompletion
 import storageService as storage_service
 
 logger = get_script_logger("archivematica.mcp.client.post_store_aip_hook")
@@ -123,6 +124,8 @@ def post_store_hook(sip_uuid):
 
     # DSPACE HANDLE TO ARCHIVESSPACE
     dspace_handle_to_archivesspace(sip_uuid)
+
+    emailOnCompletion.run_job(sip_uuid, False)
 
     # POST-STORE CALLBACK
     storage_service.post_store_aip_callback(sip_uuid)

--- a/src/MCPClient/tests/test_email_on_completion.py
+++ b/src/MCPClient/tests/test_email_on_completion.py
@@ -1,0 +1,25 @@
+# -*- coding: utf8
+
+import os
+import sys
+
+from django.core import mail
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
+
+from emailOnCompletion import send_email
+
+
+def test_send_email_ok(settings):
+    settings.DEFAULT_FROM_EMAIL = "test@testy.com"
+    total = send_email("Test Completion", ["to@testy.com"], "This is the email content",
+                       "Attachment text")
+
+    assert total == 1
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "Test Completion"
+    assert mail.outbox[0].from_email == "test@testy.com"
+    assert mail.outbox[0].to == ["to@testy.com"]
+    assert mail.outbox[0].body == "This is the email content"
+    assert len(mail.outbox[0].attachments) == 1

--- a/src/dashboard/src/main/migrations/0052_add_failure_messages.py
+++ b/src/dashboard/src/main/migrations/0052_add_failure_messages.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def data_migration(apps, schema_editor):
+    JobFailMessage = apps.get_model('main', 'JobFailMessage')
+
+    # Verify Transfer Compliance    Move to processing directory
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'b4567e89-9fea-4256-99f5-a88987026488',
+        message='''Failure to move or copy files may be due to lack of disk space.
+         Check Processing Storage Usage in the Administration screen, or contact your administrator.''',
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'0e1a8a6b-abcc-4ed6-b4fb-cbccfdc23ef5',
+        message='''Failure to move or copy files may be due to lack of disk space.
+         Check Processing Storage Usage in the Administration screen, or contact your administrator.''',
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'aa9ba088-0b1e-4962-a9d7-79d7a0cbea2d',
+        message=("Failure to move or copy files may be due to lack of disk space. "
+                 "Check Processing Storage Usage in the Administration screen, or contact your administrator."),
+    )
+    # Verify Transfer Compliance  Attempt restructure for compliance
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c',
+        message=("Failure to move or copy files may be due to lack of disk space. "
+                 "Check Processing Storage Usage in the Administration screen, or contact your administrator."),
+    )
+    # Verify Transfer Compliance  Verify Transfer Compliance
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'45063ad6-f374-4215-a2c4-ac47be4ce2cd',
+        message=("The Transfer must fixed to meet the definition of the Transfer Type to proceed, or you can reject "
+                 "the Transfer and start again. User input is required in the dashboard to select the appropriate option. "
+                 "Select \"reject\" to delete the transfer, select \"attempt restructure for compliance\" to have "
+                 "Archivematica attempt to fix the problem, or modify the Transfer contents within the "
+                 "Currently Processing directory and select \"move to ActiveTransfers\" to restart processing. "),
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'438dc1cf-9813-44b5-a0a3-58e09ae73b8a',
+        message=("The Transfer must fixed to meet the definition of the Transfer Type to proceed, or you can reject "
+                 "the Transfer and start again. User input is required in the dashboard to select the appropriate option. "
+                 "Select \"reject\" to delete the transfer, select \"attempt restructure for compliance\" to have "
+                 "Archivematica attempt to fix the problem, or modify the Transfer contents within the "
+                 "Currently Processing directory and select \"move to ActiveTransfers\" to restart processing. "),
+    )
+    # Verify transfer checksums    Verify metadata directory checksums
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'5e4bd4e8-d158-4c2a-be89-51e3e9bd4a06',
+        message=("At least one checksum provided in the Transfer is not accurate for the file "
+                 "it is meant to describe. This could be due to a problem in the checksum file, "
+                 "or may be because the file itself has been corrupted or modified since the original "
+                 "checksum was created. Check the dashboard for this job to see a list of standard errors "
+                 "for each file that had a checksum that did not pass verification."),
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'7c6a0b72-f37b-4512-87f3-267644de6f80',
+        message=("At least one checksum provided in the Transfer is not accurate for the file "
+                 "it is meant to describe. This could be due to a problem in the checksum file, "
+                 "or may be because the file itself has been corrupted or modified since the original "
+                 "checksum was created. Check the dashboard for this job to see a list of standard errors "
+                 "for each file that had a checksum that did not pass verification."),
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'f1bfce12-b637-443f-85f8-b6450ca01a13',
+        message=("At least one checksum provided in the Transfer is not accurate for the file "
+                 "it is meant to describe. This could be due to a problem in the checksum file, "
+                 "or may be because the file itself has been corrupted or modified since the original "
+                 "checksum was created. Check the dashboard for this job to see a list of standard errors "
+                 "for each file that had a checksum that did not pass verification."),
+    )
+    # Scan for viruses  Scan for viruses
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'1c2550f1-3fc0-45d8-8bc4-4c06d720283b',
+        message=("Check the Dashboard to see which files contain viruses. "
+                 "Remove infected files and start the Transfer process over again. "),
+    )
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'21d6d597-b876-4b3f-ab85-f97356f10507',
+        message=("Check the Dashboard to see which files contain viruses. "
+                 "Remove infected files and start the Transfer process over again. "),
+    )
+    # Identify File Format  Identify File Format
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'2522d680-c7d9-4d06-8b11-a28d8bd8a71f',
+        message=("Format identification will fail if any objects can't be identified. "
+                 "Consider processing the files again with a different tool."),
+    )
+    # Extract packages  Scan for viruses on extracted files
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'7d33f228-0fa8-4f4c-a66b-24f8e264c214',
+        message=("Check the Dashboard to see which files contain viruses. "
+                 "Remove infected files and start the Transfer process over again. "),
+    )
+    # Extract packages  Identifies formats of the objects in the transfer.
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'aaa929e4-5c35-447e-816a-033a66b9b90b',
+        message=("Format identification will fail if any objects can't be identified. "
+                 "Consider processing the files again with a different tool."),
+    )
+    # Store AIP  Index AIP
+    JobFailMessage.objects.create(
+        microservicechainlink_id=u'48703fad-dc44-4c8e-8f47-933df3ef6179',
+        message=("When 'Index AIP' fails, it is not possible to search for your AIP "
+                 "through the Archivematica Dashboard. You can find the AIP by logging "
+                 "into the Archivematica storage service and browsing or searching from the Packages screen."),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0051_index_aip_error'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='JobFailMessage',
+            fields=[
+                ('id', models.AutoField(serialize=False, editable=False, primary_key=True, db_column=b'pk')),
+                ('microservicechainlink', models.ForeignKey(to='main.MicroServiceChainLink', db_column=b'microServiceChainLinksPK')),
+                ('message', models.CharField(max_length=1000, db_column=b'message')),
+                ('lastmodified', models.DateTimeField(db_column=b'lastModified', auto_now=True)),
+            ],
+            options={
+                'db_table': 'JobFailMessages',
+            },
+            bases=(models.Model,),
+        ),
+
+        migrations.RunPython(data_migration)
+    ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -1013,6 +1013,16 @@ class TaskConfigUnitVariableLinkPull(models.Model):
         db_table = u'TasksConfigsUnitVariableLinkPull'
 
 
+class JobFailMessage(models.Model):
+    id = models.AutoField(primary_key=True, db_column='pk')
+    message = models.CharField(max_length=1000, null=True, blank=True, db_column='Message')
+    lastmodified = models.DateTimeField(db_column='lastModified', auto_now=True)
+    microservicechainlink = models.ForeignKey('MicroServiceChainLink', null=True, db_column='microServiceChainLinksPK')
+
+    class Meta:
+        db_table = u'JobFailMessages'
+
+
 class UnitVariable(models.Model):
     id = UUIDPkField()
     unittype = models.CharField(max_length=50, null=True, blank=True, db_column='unitType')


### PR DESCRIPTION
This is to implement simple email notification for a completed workflow according to https://jiscdev.atlassian.net/browse/RDSSARK-483.

This is to prevent users from having to use the dashboard when using an automated workflow. Any errors, non-terminal or not, are listed as part of the email. Detailed messages from associated tasks are added as an attachment although most users will not want to see this.

Failures in a type of job are given a general message to help the user in most cases. Sometimes the message directs them to the dashboard. All the messages are configurable in the database.

In this first version, the service installed as part of the email-fail-report service and as part of the post-store-aip-hook service so that is runs on success or failure. It is designed as a separate microservice so could be installed as part of the microservice chain.

Currently emails are sent to all users. This will need to be changed to send to administrative users only.

Messages in the JobFailMessage migration are a work in progress. Further messages can be added as they become available.