### PR TITLE
Dev/capture output 937

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -248,6 +248,11 @@ This is the full list of variables supported by MCPClient:
     - **Type:** `string`
     - **Default:** `3306`
 
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT`**:
+    - **Description:** controls whether or not to capture stdout from client script subprocesses.  If set to `true`, then stdout is captured; if set to `false`, then stdout is not captured. If set to `true`, then stderr is captured; if set to `false`, then stderr is captured only if the subprocess has failed, i.e., returned a non-zero exit code.
+    - **Config file example:** `MCPClient.capture_client_script_output`
+    - **Type:** `boolean`
+    - **Default:** `true`
 
 ## Logging configuration
 

--- a/src/MCPClient/lib/clientScripts/compressAIP.py
+++ b/src/MCPClient/lib/clientScripts/compressAIP.py
@@ -87,7 +87,8 @@ def compress_aip(compression, compression_level, sip_directory, sip_name, sip_uu
         return -1
 
     print('Executing command:', command)
-    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True)
+    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True,
+                                               capture_output=False)
 
     # Add new AIP File
     file_uuid = sip_uuid

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -45,6 +45,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'iboolean'},
         {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'boolean'},
     ],
+    'capture_client_script_output': {'section': 'MCPClient', 'option': 'capture_client_script_output', 'type': 'boolean'},
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
@@ -87,6 +88,7 @@ numberOfTasks = 0
 elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
 search_enabled = true
+capture_client_script_output = true
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
@@ -236,6 +238,7 @@ CLAMAV_CLIENT_MAX_FILE_SIZE = config.get('clamav_client_max_file_size')
 CLAMAV_CLIENT_MAX_SCAN_SIZE = config.get('clamav_client_max_scan_size')
 
 
+
 # Apply email settings
 globals().update(email_settings.get_settings(config))
 
@@ -246,3 +249,4 @@ except IOError:
     doc = {}
 ARCHIVEMATICA_VERSION = doc.get('version', 'UNKNOWN')
 AGENT_CODE = doc.get('agent_code', 'UNKNOWN')
+CAPTURE_CLIENT_SCRIPT_OUTPUT = config.get('capture_client_script_output')

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -35,7 +35,7 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, root="archivematica", 
         },
         'root': {  # Everything else
             'handlers': ['console'],
-            'level': 'WARNING',
+            'level': 'DEBUG',
         },
     }
 

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,0 +1,52 @@
+# -*- coding: UTF-8 -*-
+
+import shlex
+
+import executeOrRunSubProcess as execsub
+
+
+def test_capture_output():
+    """Tests behaviour of capture_output when executing sub processes."""
+
+    # Test that stdout and stderr are not captured by default
+    ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'])
+    assert std_out is ''
+    assert std_err is ''
+
+    # Test that stdout and stderr are captured when `capture_output` is
+    # enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=True)
+    assert std_out is not '' or std_err is not ''
+
+    # Test that stdout and stderr are not captured when `capture_output` is
+    # not enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=False)
+    assert std_out is ''
+    assert std_err is ''
+
+    # Test that when `capture_output` is `False`, then stdout is never returned
+    # and stderr is only returned when the exit code is non-zero.
+    cmd1 = 'sh -c \'>&2 echo "error"; echo "out"; exit 1\''
+    cmd0 = 'sh -c \'>&2 echo "error"; echo "out"; exit 0\''
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd1), capture_output=False)
+    assert std_out.strip() is ''
+    assert std_err.strip() == 'error'
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd0), capture_output=False)
+    assert std_out.strip() is ''
+    assert std_err.strip() == ''
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd1), capture_output=True)
+    assert std_out.strip() == 'out'
+    assert std_err.strip() == 'error'
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd0), capture_output=True)
+    assert std_out.strip() == 'out'
+    assert std_err.strip() == 'error'


### PR DESCRIPTION
This PR replaces #42

It cherry-picks two commits from https://github.com/artefactual/archivematica/pulls/937

From the original PR:

Adds a CAPTURE_CLIENT_SCRIPT_OUTPUT setting to the MCPClient's Django settings. This controls what is passed to executeOrRun's newly introduced capture_output kwarg. Similar kwargs added to subprocess-calling functions in executeOrRunSubProcess.py. Includes tests for correct behaviour of archivematicaCommon/lib/executeOrRunSubProcess.py::launchSubProcess.

Note: output capturing of the compression call in the compressAIP.py client script is turned off here uniformly because a lot of useless output is generated here for very large AIPs, which hampers performance.

Acceptance tests that confirm correct behaviour and performance enhancement of this feature are in artefactual-labs/acceptance tests PR 75.