### PR TITLE
Revert "Dashboard: use package endpoint in transfer browser"

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     url(r'^delete/arrange/$', views.delete_arrange),
     url(r'^create_directory_within_arrange/$', views.create_directory_within_arrange),
     url(r'^copy_to_arrange/$', views.copy_to_arrange),
+    url(r'^transfer/$', views.start_transfer_logged_in),
     url(r'^copy_from_arrange/$', views.copy_from_arrange_to_completed),
     url(r'^copy_metadata_files/$', views.copy_metadata_files_logged_in),
 ]


### PR DESCRIPTION
Revert 6b6a065dd8f13ec7bc5d34bd3b871840840c63a8 until we can make it work with Shibboleth.

This is related to #72.