### PR TITLE
MCPClient: use utf-8 in MIMEText

### DIFF
--- a/src/MCPClient/lib/clientScripts/lib/job_email_report.py
+++ b/src/MCPClient/lib/clientScripts/lib/job_email_report.py
@@ -38,7 +38,7 @@ def send_email(subject, to, content, attachment_text):
         mail = EmailMessage(subject, content,
                             mcpclient_settings.DEFAULT_FROM_EMAIL, to)
         if attachment_text:
-            attachment = MIMEText(attachment_text)
+            attachment = MIMEText(attachment_text, 'plain', 'utf-8')
             attachment.add_header('Content-Disposition', 'attachment; '
                                   'filename=TaskDetails.txt')
             mail.attach(attachment)


### PR DESCRIPTION
Set the character set explicitly to `utf-8`. This is important so unicode text generated by Archivematica can be encoded properly.

Demonstration:

```
>>> MIMEText('€', 'plain')
>>> MIMEText(u'€', 'plain')
UnicodeEncodeError: 'ascii' codec can't encode character u'\u20ac' in position 0: ordinal not in range(128)
>>> MIMEText(u'€', 'plain', 'utf-8')
```

This closes [RDSSARK-512](https://jiscdev.atlassian.net/browse/RDSSARK-512).