### PR TITLE
Pin base docker images to Jessie

### DIFF
--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.common

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.production


### PR DESCRIPTION
fixes #75

The python-2.7 tag will pull in a base docker image that now uses Debian Stretch. All testing so far has been with Debian Jessie, so we should stick with that for now.

https://www.youtube.com/watch?v=qYkbTyHXwbs