### PR TITLE
MCPClient: replace clientAssetsDirectory

### DIFF
--- a/src/MCPClient/lib/worker.py
+++ b/src/MCPClient/lib/worker.py
@@ -21,6 +21,7 @@ logger = logging.getLogger('archivematica.mcp.client')
 replacement_dict = {
     "%sharedPath%": django_settings.SHARED_DIRECTORY,
     "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
+    "%clientAssetsDirectory%": django_settings.CLIENT_ASSETS_DIRECTORY,
 }
 
 


### PR DESCRIPTION
`%clientAssetsDirectory%` was [accidentally left out from the dictionary of
replacement items (see #53)](https://github.com/JiscRDSS/archivematica/pull/53) that the MCP worker applies to the command-line arguments.

This commit puts the item back in the dictionary.

https://jiscdev.atlassian.net/browse/RDSSARK-531